### PR TITLE
[BIK-1478] Add validation to detect RadSim tags in toRadSim() functions

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
@@ -259,6 +259,9 @@ enum class BikeInfrastructure(
         // https://github.com/1prk/osm_categorizer/blob/radsim/netapy/assessor_free.py
         @Suppress("CyclomaticComplexMethod", "LongMethod", "ComplexMethod", "ReturnCount", "ComplexCondition")
         fun toRadSim(tags: Map<String, Any>): BikeInfrastructure {
+            // Validate that we're receiving OSM tags, not RadSim tags [BIK-1478]
+            TagFormatValidator.requireOsmFormat(tags, "BikeInfrastructure.toRadSim()")
+
             if ((tags.containsKey(OsmTag.ACCESS.key) && isNotAccessible(tags)) ||
                 (tags.containsKey(OsmTag.TRAM.key) && tags[OsmTag.TRAM.key] == OsmValue.YES.value)
             ) {

--- a/src/main/kotlin/de/radsim/translation/model/Speed.kt
+++ b/src/main/kotlin/de/radsim/translation/model/Speed.kt
@@ -139,6 +139,9 @@ enum class Speed(val value: String, val backMappingTag: OsmTag?) {
          */
         @Suppress("SpellCheckingInspection", "ReturnCount") // TODO
         fun toRadSim(tags: Map<String, Any>): Speed {
+            // Validate that we're receiving OSM tags, not RadSim tags [BIK-1478]
+            TagFormatValidator.requireOsmFormat(tags, "Speed.toRadSim()")
+
             // Add mappings in order: check first tag for all values, then check next tag for all values, etc.
             for (osmKey in specificOsmTags) {
                 val tagValue = tags[osmKey]?.toString() ?: continue

--- a/src/main/kotlin/de/radsim/translation/model/SurfaceType.kt
+++ b/src/main/kotlin/de/radsim/translation/model/SurfaceType.kt
@@ -206,6 +206,9 @@ enum class SurfaceType(val value: String, val backMappingTag: OsmTag) {
          */
         @SuppressWarnings("ReturnCount") // TODO
         fun toRadSim(tags: Map<String, Any>): SurfaceType {
+            // Validate that we're receiving OSM tags, not RadSim tags [BIK-1478]
+            TagFormatValidator.requireOsmFormat(tags, "SurfaceType.toRadSim()")
+
             // Iterate through mapping list first to ensure hierarchical checks
             for (mapping in MAPPINGS) {
                 val osmKey = mapping.tagKey

--- a/src/main/kotlin/de/radsim/translation/model/TagFormatValidator.kt
+++ b/src/main/kotlin/de/radsim/translation/model/TagFormatValidator.kt
@@ -1,0 +1,96 @@
+package de.radsim.translation.model
+
+/**
+ * Validates tag format to ensure `.toRadSim()` functions receive OSM tags, not RadSim tags.
+ *
+ * The three formats are distinguished by their keys:
+ * - **OSM format**: Uses OSM tag keys like "highway", "cycleway", "bicycle", "maxspeed" (lowercase), etc.
+ * - **RadSim Simplified format**: Uses "roadStyleSimplified", "maxSpeed", "surface"
+ * - **RadSim Full format**: Uses "roadStyle", "maxSpeed", "surface"
+ */
+internal object TagFormatValidator {
+
+    /**
+     * The distinguishing key for RadSim Simplified format.
+     */
+    private const val RADSIM_SIMPLIFIED_KEY = "roadStyleSimplified"
+
+    /**
+     * The distinguishing key for RadSim Full format.
+     */
+    private const val RADSIM_FULL_KEY = "roadStyle"
+
+    /**
+     * Checks if the tags are in OSM format.
+     *
+     * @param tags The tags to check
+     * @return true if tags appear to be in OSM format (no RadSim keys detected)
+     */
+    fun isOsmFormat(tags: Map<String, Any>): Boolean {
+        return !tags.containsKey(RADSIM_SIMPLIFIED_KEY) && !tags.containsKey(RADSIM_FULL_KEY)
+    }
+
+    /**
+     * Checks if the tags are in RadSim Simplified format.
+     *
+     * @param tags The tags to check
+     * @return true if tags contain the "roadStyleSimplified" key
+     */
+    fun isRadSimSimplifiedFormat(tags: Map<String, Any>): Boolean {
+        return tags.containsKey(RADSIM_SIMPLIFIED_KEY)
+    }
+
+    /**
+     * Checks if the tags are in RadSim Full format.
+     *
+     * @param tags The tags to check
+     * @return true if tags contain the "roadStyle" key (without "Simplified")
+     */
+    fun isRadSimFullFormat(tags: Map<String, Any>): Boolean {
+        return tags.containsKey(RADSIM_FULL_KEY)
+    }
+
+    /**
+     * Validates that the given tags are in OSM format (not RadSim format).
+     *
+     * @param tags The tags to validate
+     * @param callerFunction The name of the function calling this (for error messages)
+     * @throws IllegalArgumentException if RadSim tags are detected
+     */
+    fun requireOsmFormat(tags: Map<String, Any>, callerFunction: String) {
+        when {
+            isRadSimSimplifiedFormat(tags) -> {
+                throw IllegalArgumentException(
+                    "$callerFunction expects OSM tags but received RadSim Simplified tags! " +
+                        "Found key '$RADSIM_SIMPLIFIED_KEY' in: ${tags.keys}. " +
+                        "This indicates Way.properties.attributes (RadSim tags) are being passed instead of " +
+                        "WayAttributes.wayTags (OSM tags). " +
+                        "Check PlanChangesetMerger.mergeImmutable() or Simulator.annotateTagsAndRelationIds()."
+                )
+            }
+            isRadSimFullFormat(tags) -> {
+                throw IllegalArgumentException(
+                    "$callerFunction expects OSM tags but received RadSim Full tags! " +
+                        "Found key '$RADSIM_FULL_KEY' in: ${tags.keys}. " +
+                        "This indicates Way.properties.attributes (RadSim tags) are being passed instead of " +
+                        "WayAttributes.wayTags (OSM tags). " +
+                        "Check PlanChangesetMerger.mergeImmutable() or Simulator.annotateTagsAndRelationIds()."
+                )
+            }
+        }
+    }
+
+    /**
+     * Gets the detected tag format as a string for debugging.
+     *
+     * @param tags The tags to check
+     * @return "OSM", "RadSim Simplified", or "RadSim Full"
+     */
+    fun getTagFormat(tags: Map<String, Any>): String {
+        return when {
+            isRadSimSimplifiedFormat(tags) -> "RadSim Simplified"
+            isRadSimFullFormat(tags) -> "RadSim Full"
+            else -> "OSM"
+        }
+    }
+}


### PR DESCRIPTION
Adds TagFormatValidator to prevent the bug where RadSim tags are accidentally passed to .toRadSim() converters which expect OSM tags.

The validator distinguishes between three tag formats based on keys:
- OSM format: Uses OSM tag keys (highway, cycleway, maxspeed, etc.)
- RadSim Simplified: Contains "roadStyleSimplified" key
- RadSim Full: Contains "roadStyle" key

Validation is added at the start of:
- BikeInfrastructure.toRadSim()
- Speed.toRadSim()
- SurfaceType.toRadSim()

If RadSim tags are detected, throws IllegalArgumentException with detailed error message indicating the source of the problem.

This prevents the bug where Simulator.annotateTagsAndRelationIds() injects RadSim tags from Way.properties.attributes instead of OSM tags from WayAttributes.wayTags, causing FeatureExtractor to fail.