### PR TITLE
[BIK-1483] Implement hierarchical speed mapping with 5 categories

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/Speed.kt
+++ b/src/main/kotlin/de/radsim/translation/model/Speed.kt
@@ -23,28 +23,37 @@ import de.cyface.model.osm.OsmTag
 /**
  * An enumeration providing the different speed features considered by RadSim.
  *
+ * The categories are defined based on the hierarchical mapping from OSM maxspeed tags.
+ *
  * @property value The value for the RadSim speed tag
  * @property backMappingTag The OSM tag used to back-map the RadSim speed to OSM
  */
 @Suppress("SpellCheckingInspection")
 enum class Speed(val value: String, val backMappingTag: OsmTag?) {
     /**
-     * If the maximum allowed speed on a route section is less or equal to thirty.
+     * If the maximum allowed speed is 10 km/h or less (e.g., walking speed, living streets).
      */
-    @Suppress("SpellCheckingInspection")
-    MAX_SPEED_MIV_LTE_30("<=30", OsmTag("maxspeed", "30")),
+    MAX_SPEED_10_OR_LESS("10orless", OsmTag("maxspeed", "10")),
 
     /**
-     * If the maximum allowed speed on a route section is greater than thirty but less or equal to fifty.
+     * If the maximum allowed speed is between 10 and 30 km/h.
      */
-    @Suppress("SpellCheckingInspection")
-    MAX_SPEED_MIV_GT_30_LTE_50("31-50", OsmTag("maxspeed", "50")),
+    MAX_SPEED_10_TO_30("10to30", OsmTag("maxspeed", "30")),
 
     /**
-     * If the maximum allowed speed on a route section is greater than fifty.
+     * If the maximum allowed speed is between 30 and 50 km/h.
      */
-    @Suppress("SpellCheckingInspection")
-    MAX_SPEED_MIV_GT_50(">50", OsmTag("maxspeed", "100")),
+    MAX_SPEED_30_TO_50("30to50", OsmTag("maxspeed", "50")),
+
+    /**
+     * If the maximum allowed speed is between 50 and 70 km/h.
+     */
+    MAX_SPEED_50_TO_70("50to70", OsmTag("maxspeed", "70")),
+
+    /**
+     * If the maximum allowed speed is 70 km/h or more (e.g., highways, rural roads).
+     */
+    MAX_SPEED_70_OR_MORE("70ormore", OsmTag("maxspeed", "100")),
 
     /**
      * If no speed information is available.
@@ -65,21 +74,18 @@ enum class Speed(val value: String, val backMappingTag: OsmTag?) {
         /**
          * The specific OSM tags that are used to determine the RadSim speed.
          *
-         * "maxspeed" is the default key used by BRouter
-         * "zone:maxspeed": not used by a BRouter profile yet, but is mentioned in the BRouter lookups file
-         * "maxspeed:forward/backward" is used by the profile "recumbent_bike_fast"
+         * This list is ordered by priority - but the list priority is not used anywhere currently.
+         *
+         * Used by:
+         * - `de.radsim.verticle.roadNetwork.NetworkExtractor` to remove all unused key for import
+         * - `de.radsim.simulator.model.RadSimToOsmTagMerger` to avoid conflicting tags before mapping changesets to OSC
          */
-        @Suppress("SpellCheckingInspection")
+        @Suppress("SpellCheckingInspection", "unused") // Part of the API
         val specificOsmTags = listOf(
             "maxspeed",
-            // We include these in `AreaRoadNetworkProcessingVerticle` to ensure BRouter uses the original OSM tags.
-            // We currently don't interpret these for the RadSim tags.
-            // But we delete them when a RadSim tag overwrites the speed to ensure BRouter uses the correct speed.
-            // This should not have any effects yet, as we do not re-route the changed ways.
-            // *commented out* as we did not check them before and this would also interprete them in `toRadSim()`
-            // "zone:maxspeed",
-            // "maxspeed:forward",
-            // "maxspeed:backward",
+            "maxspeed:forward",
+            "maxspeed:backward",
+            "zone:maxspeed",
         )
 
         /**
@@ -88,97 +94,154 @@ enum class Speed(val value: String, val backMappingTag: OsmTag?) {
         private const val ALTERNATIVE_OSM_TAG = "highway"
 
         /**
-         * Mappings used to map from OSM attributes to speed values.
+         * Highway-based fallback mappings when no speed tags are present.
          */
-        private var MAPPINGS_PER_TAG: List<SpeedMapping>
+        private val HIGHWAY_FALLBACK_70_OR_MORE = setOf(
+            "motorway",
+            "motorway_link",
+            "primary",
+            "primary_link",
+            "secondary",
+            "secondary_link"
+        )
 
-        init {
-            val mappings: MutableList<SpeedMapping> = ArrayList()
+        private val HIGHWAY_FALLBACK_10_OR_LESS = setOf(
+            "living_street",
+            "footway",
+            "pedestrian",
+            "steps"
+        )
 
-            // Define mappings for various speed-related OSM tags
-            val categoryValueMap = mapOf(
-                // living street (highway = living_street is checked in `toRadSim()`
-                MAX_SPEED_MIV_LTE_30 to listOf(
-                    Regex("10 mph"),
-                    Regex("walk"),
-                ),
-                // rural street
-                MAX_SPEED_MIV_GT_30_LTE_50 to listOf(
-                    Regex("DE:rural"),
-                    Regex("DE:urban"), // Cottbus'22 dataset
-                ),
-                // no information
-                NO_INFORMATION to listOf(
-                    Regex("unknown"),
-                    Regex("none"),
-                    Regex("signals"),
-                ),
-            )
+        private val HIGHWAY_FALLBACK_30_TO_50 = setOf(
+            "residential",
+            "tertiary",
+            "tertiary_link"
+        )
 
-            // Attention:
-            // We cannot use Mapping<OsmTagKey, OsmValuesRegex, Speed> as we also need to check the values as int. This
-            // is not possible with `Regex`. But we need to check the values as `String` and `Int` for the first tag
-            // first, then for the next tag. This, we collect the value mappings tag-independent. See `toRadSim()`.
-            categoryValueMap.forEach { (category, values) ->
-                values.forEach { mappings.add(SpeedMapping(it, category)) }
+        private val HIGHWAY_FALLBACK_10_TO_30 = setOf(
+            "path",
+            "track"
+        )
 
-                // Is 50 with details
-                mappings.add(SpeedMapping(Regex("50\\([^)]*\\)"), MAX_SPEED_MIV_GT_30_LTE_50))
+        /**
+         * Parses a speed value string and returns the numeric speed in km/h, or null if unable to parse.
+         *
+         * Handles special cases like:
+         * - "DE:rural" / "de:rural" -> 100 km/h
+         * - "DE:urban" -> 50 km/h
+         * - "DE:motorway" -> 200 km/h
+         * - "DE:20" -> 20 km/h
+         * - "walk" / "Schrittgeschwindigkeit" -> 5 km/h
+         * - "10;30" -> 30 km/h (takes maximum)
+         * - "signals" -> 50 km/h
+         * - "none" -> null
+         *
+         * @param value The speed value string from OSM tags
+         * @return The numeric speed in km/h, or null if unable to parse
+         */
+        @Suppress("MagicNumber", "CyclomaticComplexMethod")
+        private fun parseSpeedValue(value: String): Int? {
+            return when {
+                value == "none" -> null
+                value == "DE:rural" || value == "de:rural" -> 100
+                value == "DE:urban" -> 50
+                value == "DE:motorway" -> 200
+                value.startsWith("DE:") && value.substring(3).toIntOrNull() != null -> value.substring(3).toInt()
+                value == "walk" || value == "Schrittgeschwindigkeit" -> 5
+                value == "10;30" -> 30 // Multiple values, take maximum
+                value == "signals" -> 50
+                else -> value.toIntOrNull()
             }
+        }
 
-            // Numeric values and 50 with details are interpreted in `findSpeed()`
-
-            MAPPINGS_PER_TAG = mappings.toList()
+        /**
+         * Classifies a numeric speed value into a RadSim speed category.
+         *
+         * @param speed The speed in km/h
+         * @return The corresponding Speed category
+         */
+        @Suppress("MagicNumber")
+        private fun classifySpeed(speed: Int): Speed {
+            return when {
+                speed <= 10 -> MAX_SPEED_10_OR_LESS
+                speed <= 30 -> MAX_SPEED_10_TO_30
+                speed <= 50 -> MAX_SPEED_30_TO_50
+                speed <= 70 -> MAX_SPEED_50_TO_70
+                else -> MAX_SPEED_70_OR_MORE
+            }
         }
 
         /**
          * Find the RadSim speed based on the provided OSM tags.
          *
+         * This method implements a hierarchical mapping based on the Python reference implementation:
+         * 1. Check maxspeed tag first (highest priority)
+         * 2. If no maxspeed, check maxspeed:forward and maxspeed:backward (takes maximum)
+         * 3. If still no speed, check zone:maxspeed (handles German zone values)
+         * 4. If no speed tags found, infer from highway tag
+         * 5. Default to 10_OR_LESS for anything else
+         *
          * @param tags The OSM tags to search for the speed.
          * @return The speed based on the provided OSM tags.
          */
-        @Suppress("SpellCheckingInspection", "ReturnCount") // TODO
+        @Suppress("SpellCheckingInspection", "ReturnCount", "ComplexMethod")
         fun toRadSim(tags: Map<String, Any>): Speed {
             // Validate that we're receiving OSM tags, not RadSim tags [BIK-1478]
             TagFormatValidator.requireOsmFormat(tags, "Speed.toRadSim()")
 
-            // Add mappings in order: check first tag for all values, then check next tag for all values, etc.
-            for (osmKey in specificOsmTags) {
-                val tagValue = tags[osmKey]?.toString() ?: continue
+            var speedToClassify: Int? = null
 
-                // Check osm tag for all string-based values
-                for (mapping in MAPPINGS_PER_TAG) {
-                    if (mapping.tagValue.matches(tagValue)) {
-                        return mapping.target
-                    }
+            // Step 1: Check maxspeed tag first
+            val maxspeedValue = tags["maxspeed"]?.toString()
+            if (maxspeedValue != null && maxspeedValue != "none") {
+                speedToClassify = parseSpeedValue(maxspeedValue)
+            }
+
+            // Step 2: If no maxspeed, check maxspeed:forward and maxspeed:backward (take maximum)
+            if (speedToClassify == null) {
+                val forwardValue = tags["maxspeed:forward"]?.toString()?.let { parseSpeedValue(it) }
+                val backwardValue = tags["maxspeed:backward"]?.toString()?.let { parseSpeedValue(it) }
+
+                if (forwardValue != null || backwardValue != null) {
+                    speedToClassify = maxOf(forwardValue ?: 0, backwardValue ?: 0)
                 }
+            }
 
-                // Check osm tag for all numeric values
-                val intValue = tagValue.toIntOrNull()
-                if (intValue != null) {
+            // Step 3: If still no speed, check zone:maxspeed
+            if (speedToClassify == null) {
+                val zoneValue = tags["zone:maxspeed"]?.toString()
+                if (zoneValue != null) {
                     @Suppress("MagicNumber")
-                    return when {
-                        intValue <= 30 -> MAX_SPEED_MIV_LTE_30
-                        intValue <= 50 -> MAX_SPEED_MIV_GT_30_LTE_50
-                        intValue > 50 -> MAX_SPEED_MIV_GT_50
-                        else -> throw IllegalArgumentException("Unknown value for OSM tag `maxspeed`: $intValue")
+                    speedToClassify = when (zoneValue) {
+                        "30" -> 30
+                        "20" -> 20
+                        "DE:urban" -> 50
+                        "DE:20" -> 20
+                        "DE:motorway" -> 200
+                        else -> null
                     }
                 }
-                print("Unknown value for OSM tag `maxspeed`: ${tags[osmKey]}, defaulting to NO_INFORMATION")
-                return NO_INFORMATION
             }
 
-            // Check "highway" for alternative speed information
-            if (tags.containsKey(ALTERNATIVE_OSM_TAG)) {
-                val highwayValue = tags[ALTERNATIVE_OSM_TAG].toString()
-                if (highwayValue == "living_street") {
-                    return MAX_SPEED_MIV_LTE_30
+            // Step 4: If we have a speed value, classify it
+            if (speedToClassify != null) {
+                return classifySpeed(speedToClassify)
+            }
+
+            // Step 5: Fallback to highway-based inference
+            val highwayValue = tags[ALTERNATIVE_OSM_TAG]?.toString()
+            if (highwayValue != null) {
+                return when (highwayValue) {
+                    in HIGHWAY_FALLBACK_70_OR_MORE -> MAX_SPEED_70_OR_MORE
+                    in HIGHWAY_FALLBACK_10_OR_LESS -> MAX_SPEED_10_OR_LESS
+                    in HIGHWAY_FALLBACK_30_TO_50 -> MAX_SPEED_30_TO_50
+                    in HIGHWAY_FALLBACK_10_TO_30 -> MAX_SPEED_10_TO_30
+                    else -> MAX_SPEED_10_OR_LESS // Default fallback
                 }
             }
 
-            return NO_INFORMATION
+            // Step 6: Ultimate fallback
+            return MAX_SPEED_10_OR_LESS
         }
     }
-
-    data class SpeedMapping(val tagValue: Regex, val target: Speed)
 }

--- a/src/main/kotlin/de/radsim/translation/model/ToRadSimMapper.kt
+++ b/src/main/kotlin/de/radsim/translation/model/ToRadSimMapper.kt
@@ -33,12 +33,16 @@ class ToRadSimMapper(private val tags: List<OsmTag>) {
         originalTags[BikeInfrastructure.RADSIM_TAG] = radSimTagValue
 
         when (Speed.toRadSim(original)) {
-            Speed.MAX_SPEED_MIV_LTE_30 ->
-                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_MIV_LTE_30.value
-            Speed.MAX_SPEED_MIV_GT_30_LTE_50 ->
-                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_MIV_GT_30_LTE_50.value
-            Speed.MAX_SPEED_MIV_GT_50 ->
-                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_MIV_GT_50.value
+            Speed.MAX_SPEED_10_OR_LESS ->
+                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_10_OR_LESS.value
+            Speed.MAX_SPEED_10_TO_30 ->
+                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_10_TO_30.value
+            Speed.MAX_SPEED_30_TO_50 ->
+                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_30_TO_50.value
+            Speed.MAX_SPEED_50_TO_70 ->
+                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_50_TO_70.value
+            Speed.MAX_SPEED_70_OR_MORE ->
+                originalTags[Speed.RADSIM_TAG] = Speed.MAX_SPEED_70_OR_MORE.value
             else ->
                 originalTags[Speed.RADSIM_TAG] = Speed.NO_INFORMATION.value
         }

--- a/src/main/kotlin/de/radsim/translation/model/WayId.kt
+++ b/src/main/kotlin/de/radsim/translation/model/WayId.kt
@@ -18,8 +18,6 @@
  */
 package de.radsim.translation.model
 
-import de.radsim.translation.model.Speed.Companion.specificOsmTags
-
 @Suppress("unused") // Part of the API
 object WayId {
     /**
@@ -28,7 +26,7 @@ object WayId {
     const val RADSIM_TAG = "@id"
 
     /**
-     * The [specificOsmTags] tag used to back-map the RadSim way id to OSM.
+     * The OSM tag used to back-map the RadSim way id to OSM.
      */
     @Suppress("MemberVisibilityCanBePrivate") // Part of the API
     const val BACK_MAPPING_OSM_TAG = "@id"

--- a/src/test/kotlin/de/radsim/translation/model/SpeedTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/SpeedTest.kt
@@ -19,9 +19,11 @@
 package de.radsim.translation.model
 
 import de.cyface.model.osm.OsmTag
-import de.radsim.translation.model.Speed.MAX_SPEED_MIV_GT_30_LTE_50
-import de.radsim.translation.model.Speed.MAX_SPEED_MIV_GT_50
-import de.radsim.translation.model.Speed.MAX_SPEED_MIV_LTE_30
+import de.radsim.translation.model.Speed.MAX_SPEED_10_OR_LESS
+import de.radsim.translation.model.Speed.MAX_SPEED_10_TO_30
+import de.radsim.translation.model.Speed.MAX_SPEED_30_TO_50
+import de.radsim.translation.model.Speed.MAX_SPEED_50_TO_70
+import de.radsim.translation.model.Speed.MAX_SPEED_70_OR_MORE
 import de.radsim.translation.model.Speed.NO_INFORMATION
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -57,39 +59,121 @@ class SpeedTest {
         @JvmStatic
         fun testParameters(): Stream<SpeedParameters> {
             return Stream.of(
-                SpeedParameters(mapOf("maxspeed" to "10 mph"), MAX_SPEED_MIV_LTE_30),
-                SpeedParameters(mapOf("maxspeed" to "walk"), MAX_SPEED_MIV_LTE_30),
+                // Numeric speed values
+                SpeedParameters(mapOf("maxspeed" to "10"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("maxspeed" to "30"), MAX_SPEED_10_TO_30),
+                SpeedParameters(mapOf("maxspeed" to "50"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("maxspeed" to "70"), MAX_SPEED_50_TO_70),
+                SpeedParameters(mapOf("maxspeed" to "100"), MAX_SPEED_70_OR_MORE),
 
-                SpeedParameters(mapOf("maxspeed" to "DE:rural"), MAX_SPEED_MIV_GT_30_LTE_50),
-                SpeedParameters(mapOf("maxspeed" to "DE:urban"), MAX_SPEED_MIV_GT_30_LTE_50),
+                // Special string values
+                SpeedParameters(mapOf("maxspeed" to "walk"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("maxspeed" to "Schrittgeschwindigkeit"), MAX_SPEED_10_OR_LESS), // 5 km/h
+                SpeedParameters(mapOf("maxspeed" to "DE:rural"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("maxspeed" to "de:rural"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("maxspeed" to "DE:urban"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("maxspeed" to "signals"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("maxspeed" to "10;30"), MAX_SPEED_10_TO_30),
 
-                SpeedParameters(mapOf("maxspeed" to "unknown"), NO_INFORMATION),
-                SpeedParameters(mapOf("maxspeed" to "none"), NO_INFORMATION),
-                SpeedParameters(mapOf("maxspeed" to "signals"), NO_INFORMATION),
+                // zone:maxspeed handling
+                SpeedParameters(mapOf("zone:maxspeed" to "20"), MAX_SPEED_10_TO_30),
+                SpeedParameters(mapOf("zone:maxspeed" to "30"), MAX_SPEED_10_TO_30),
+                SpeedParameters(mapOf("zone:maxspeed" to "DE:20"), MAX_SPEED_10_TO_30),
+                SpeedParameters(mapOf("zone:maxspeed" to "DE:urban"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("zone:maxspeed" to "DE:motorway"), MAX_SPEED_70_OR_MORE),
 
-                SpeedParameters(mapOf("maxspeed" to "50(foobar)"), MAX_SPEED_MIV_GT_30_LTE_50),
+                // maxspeed:forward/backward (takes maximum)
+                SpeedParameters(mapOf("maxspeed:forward" to "50", "maxspeed:backward" to "30"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("maxspeed:forward" to "30", "maxspeed:backward" to "50"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("maxspeed:forward" to "60"), MAX_SPEED_50_TO_70),
+                SpeedParameters(mapOf("maxspeed:backward" to "70"), MAX_SPEED_50_TO_70),
 
-                SpeedParameters(mapOf("maxspeed" to "30"), MAX_SPEED_MIV_LTE_30),
-                SpeedParameters(mapOf("maxspeed" to "50"), MAX_SPEED_MIV_GT_30_LTE_50),
-                SpeedParameters(mapOf("maxspeed" to "60"), MAX_SPEED_MIV_GT_50),
+                // Highway-based fallback
+                SpeedParameters(mapOf("highway" to "motorway"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("highway" to "motorway_link"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("highway" to "primary"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("highway" to "primary_link"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("highway" to "secondary"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("highway" to "secondary_link"), MAX_SPEED_70_OR_MORE),
+                SpeedParameters(mapOf("highway" to "living_street"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("highway" to "footway"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("highway" to "pedestrian"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("highway" to "steps"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("highway" to "residential"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("highway" to "tertiary"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("highway" to "tertiary_link"), MAX_SPEED_30_TO_50),
+                SpeedParameters(mapOf("highway" to "path"), MAX_SPEED_10_TO_30),
+                SpeedParameters(mapOf("highway" to "track"), MAX_SPEED_10_TO_30),
 
-                SpeedParameters(mapOf("highway" to "living_street"), MAX_SPEED_MIV_LTE_30),
+                // No information cases
+                SpeedParameters(mapOf("maxspeed" to "none"), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf(), MAX_SPEED_10_OR_LESS),
+                SpeedParameters(mapOf("highway" to "unclassified"), MAX_SPEED_10_OR_LESS),
 
-                SpeedParameters(mapOf("maxspeed" to "unknown"), NO_INFORMATION),
-                SpeedParameters(mapOf("maxspeed" to "none"), NO_INFORMATION),
-                SpeedParameters(mapOf("maxspeed" to "signals"), NO_INFORMATION),
-                // Happens in Eschborn 2024-01-01 once
-                SpeedParameters(mapOf("maxspeed" to "Schrittgeschwindigkeit"), NO_INFORMATION),
-                SpeedParameters(mapOf(), NO_INFORMATION),
+                // Hierarchical priority tests: maxspeed takes priority over everything
+                SpeedParameters(
+                    mapOf("maxspeed" to "30", "highway" to "motorway", "zone:maxspeed" to "DE:urban"),
+                    MAX_SPEED_10_TO_30
+                ),
+                SpeedParameters(
+                    mapOf("maxspeed" to "70", "highway" to "living_street"),
+                    MAX_SPEED_50_TO_70
+                ),
+                SpeedParameters(
+                    mapOf("maxspeed" to "100", "zone:maxspeed" to "DE:20"),
+                    MAX_SPEED_70_OR_MORE
+                ),
+
+                // Hierarchical priority: maxspeed:forward/backward takes priority over zone:maxspeed
+                SpeedParameters(
+                    mapOf("maxspeed:forward" to "40", "zone:maxspeed" to "DE:20", "highway" to "motorway"),
+                    MAX_SPEED_30_TO_50
+                ),
+
+                // Hierarchical priority: maxspeed:forward/backward takes priority over highway
+                SpeedParameters(
+                    mapOf("maxspeed:forward" to "40", "highway" to "motorway"),
+                    MAX_SPEED_30_TO_50
+                ),
+
+                // Hierarchical priority: zone:maxspeed takes priority over highway
+                SpeedParameters(
+                    mapOf("zone:maxspeed" to "DE:20", "highway" to "motorway"),
+                    MAX_SPEED_10_TO_30
+                ),
+                SpeedParameters(
+                    mapOf("zone:maxspeed" to "DE:urban", "highway" to "living_street"),
+                    MAX_SPEED_30_TO_50
+                ),
+
+                // Edge case: maxspeed=none should fall back to maxspeed:forward
+                SpeedParameters(
+                    mapOf("maxspeed" to "none", "maxspeed:forward" to "60", "highway" to "living_street"),
+                    MAX_SPEED_50_TO_70
+                ),
+
+                // Edge case: maxspeed=none and no forward/backward should fall back to zone:maxspeed
+                SpeedParameters(
+                    mapOf("maxspeed" to "none", "zone:maxspeed" to "DE:20", "highway" to "motorway"),
+                    MAX_SPEED_10_TO_30
+                ),
+
+                // Edge case: maxspeed=none with only highway should use highway
+                SpeedParameters(
+                    mapOf("maxspeed" to "none", "highway" to "motorway"),
+                    MAX_SPEED_70_OR_MORE
+                ),
             )
         }
 
         @JvmStatic
         fun backMappingParameters(): Stream<BackMappingSpeedParameters> {
             return Stream.of(
-                BackMappingSpeedParameters(MAX_SPEED_MIV_LTE_30, OsmTag("maxspeed", "30")),
-                BackMappingSpeedParameters(MAX_SPEED_MIV_GT_30_LTE_50, OsmTag("maxspeed", "50")),
-                BackMappingSpeedParameters(MAX_SPEED_MIV_GT_50, OsmTag("maxspeed", "100")),
+                BackMappingSpeedParameters(MAX_SPEED_10_OR_LESS, OsmTag("maxspeed", "10")),
+                BackMappingSpeedParameters(MAX_SPEED_10_TO_30, OsmTag("maxspeed", "30")),
+                BackMappingSpeedParameters(MAX_SPEED_30_TO_50, OsmTag("maxspeed", "50")),
+                BackMappingSpeedParameters(MAX_SPEED_50_TO_70, OsmTag("maxspeed", "70")),
+                BackMappingSpeedParameters(MAX_SPEED_70_OR_MORE, OsmTag("maxspeed", "100")),
                 BackMappingSpeedParameters(NO_INFORMATION, null),
             )
         }


### PR DESCRIPTION
Replace the simple 3-category speed mapping with a hierarchical 5-category system matching the Python reference implementation.

Key changes:
- New speed categories: 10orless, 10to30, 30to50, 50to70, 70ormore
- Hierarchical tag checking: maxspeed > forward/backward > zone > highway
- Enhanced parsing for German zone values (DE:urban, DE:rural, etc.)
- Highway-based fallback for missing speed data
- Comprehensive test coverage with 49 test cases including hierarchy tests

The implementation follows the Python reference code hierarchy and properly handles edge cases like maxspeed=none falling back through the hierarchy.