### PR TITLE
Fix back-mapping stall for service roads to CYCLE_HIGHWAY

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -33,11 +33,15 @@ object BackMappingRules {
         RuleKey(NO, BICYCLE_ROAD) to { _ ->
             setOf(OsmTag("highway", "residential"), OsmTag("bicycle_road", "yes"))
         },
-        RuleKey(NO, CYCLE_HIGHWAY) to { _ ->
+        RuleKey(NO, CYCLE_HIGHWAY) to { tags ->
             // Added, even though this is not a way tags (cycle_highway)
-            setOf(
-                OsmTag("cycle_highway", "yes"),
-            )
+            val highway = tags["highway"] as? String
+            val maybeHighwayChange = if (highway == "service") {
+                setOf(OsmTag("highway", "cycleway"))
+            } else {
+                emptySet()
+            }
+            maybeHighwayChange + OsmTag("cycle_highway", "yes")
         },
         // R19
         RuleKey(NO, BICYCLE_WAY) to { _ ->

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -171,4 +171,29 @@ class BackMappingRulesTest {
         )
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `NO to CYCLE_HIGHWAY - with service road`() {
+        val expected = tags(
+            "highway" to "cycleway",
+            "cycle_highway" to "yes"
+        )
+        val actual = BackMappingRules.applyRule(
+            SimplifiedBikeInfrastructure.NO,
+            SimplifiedBikeInfrastructure.CYCLE_HIGHWAY,
+            mapOf("highway" to "service", "service" to "parking_aisle", "access" to "private")
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `NO to CYCLE_HIGHWAY - without service road`() {
+        val expected = tags("cycle_highway" to "yes")
+        val actual = BackMappingRules.applyRule(
+            SimplifiedBikeInfrastructure.NO,
+            SimplifiedBikeInfrastructure.CYCLE_HIGHWAY,
+            mapOf("highway" to "residential")
+        )
+        assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
Fixed IllegalStateException when transforming service roads (highway=service) to CYCLE_HIGHWAY category. The issue occurred because the NO → CYCLE_HIGHWAY rule only added cycle_highway=yes without changing the highway tag, causing the classification to remain NO (via SERVICE_MISC) and triggering a stall.

Changes:
- Update NO → CYCLE_HIGHWAY rule to change highway=service to highway=cycleway
- Add test case for service road → CYCLE_HIGHWAY transition
- Add test case for non-service road → CYCLE_HIGHWAY (no highway change needed)

This fixes the error:
"Back-mapping stalled: NO → CYCLE_HIGHWAY produced no category change"