### PR TITLE
[BIK-1563] Add number of lanes OSM to RadSim mapping

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/NumberOfLanes.kt
+++ b/src/main/kotlin/de/radsim/translation/model/NumberOfLanes.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 Cyface GmbH
+ *
+ * This file is part of the RadSim Translation Model.
+ *
+ *  The RadSim Translation Model is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The RadSim Translation Model is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the RadSim Translation Model.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.radsim.translation.model
+
+import de.cyface.model.osm.OsmTag
+
+/**
+ * A class providing the number of lanes mapping from OSM to RadSim.
+ *
+ * The mapping follows this hierarchy:
+ * 1. Check `lanes` tag first
+ * 2. If no `lanes`, sum `lanes:backward` and `lanes:forward`
+ * 3. If still no lanes info, infer from `highway` tag
+ */
+object NumberOfLanes {
+    /**
+     * The RadSim tag used to store the number of lanes information.
+     */
+    const val RADSIM_TAG = "noOfLanes"
+
+    /**
+     * The specific OSM tags that are used to determine the RadSim number of lanes.
+     *
+     * This list is ordered by priority - but the list priority is not used anywhere currently.
+     *
+     * Used by:
+     * - `de.radsim.verticle.roadNetwork.NetworkExtractor` to remove all unused key for import
+     * - `de.radsim.simulator.model.RadSimToOsmTagMerger` to avoid conflicting tags before mapping changesets to OSC
+     */
+    @Suppress("unused") // Part of the API
+    val specificOsmTags = listOf(
+        "lanes",
+        "lanes:forward",
+        "lanes:backward",
+    )
+
+    /**
+     * The alternative OSM tag used to estimate the number of lanes when no other lane tags are set.
+     */
+    private const val ALTERNATIVE_OSM_TAG = "highway"
+
+    /**
+     * Highway types that typically have no car lanes (0 lanes).
+     */
+    private val HIGHWAY_FALLBACK_0_LANES = setOf(
+        "footway",
+        "steps",
+        "cycleway",
+        "pedestrian",
+        "platform",
+        "elevator",
+        "bridleway",
+        "bus_stop"
+    )
+
+    /**
+     * Highway types that typically have 1 lane.
+     */
+    private val HIGHWAY_FALLBACK_1_LANE = setOf(
+        "track",
+        "path",
+        "service",
+        "residential",
+        "living_street",
+        "unclassified",
+        "construction",
+        "proposed",
+        "rest_area",
+        "raceway",
+        "tertiary_link",
+        "secondary_link",
+        "primary_link",
+        "trunk_link"
+    )
+
+    /**
+     * Highway types that typically have 2 lanes.
+     */
+    private val HIGHWAY_FALLBACK_2_LANES = setOf(
+        "tertiary",
+        "secondary",
+        "primary"
+    )
+
+    /**
+     * Parses a lanes value string and returns the numeric count, or null if unable to parse.
+     *
+     * @param value The lanes value string from OSM tags
+     * @return The numeric lane count, or null if unable to parse
+     */
+    private fun parseLanesValue(value: String): Int? {
+        return value.toIntOrNull()
+    }
+
+    /**
+     * Find the RadSim number of lanes based on the provided OSM tags.
+     *
+     * This method implements a hierarchical mapping:
+     * 1. Check `lanes` tag first (highest priority)
+     * 2. If no `lanes`, sum `lanes:forward` and `lanes:backward`
+     * 3. If still no lanes info, infer from `highway` tag
+     * 4. Default to 1 lane for anything else
+     *
+     * Optimized to minimize parseLanesValue() calls [BIK-1483 performance]
+     *
+     * @param tags The OSM tags to search for the number of lanes.
+     * @return The number of lanes based on the provided OSM tags.
+     */
+    @Suppress("ReturnCount")
+    fun toRadSim(tags: Map<String, Any>): Int {
+        // Validate that we're receiving OSM tags, not RadSim tags [BIK-1478]
+        TagFormatValidator.requireOsmFormat(tags, "NumberOfLanes.toRadSim()")
+
+        // Step 1: Check lanes tag first (most common case - short circuit if found)
+        tags["lanes"]?.toString()?.let { lanesValue ->
+            parseLanesValue(lanesValue)?.let { return it }
+        }
+
+        // Step 2: If no lanes, sum lanes:forward and lanes:backward
+        val forwardValue = tags["lanes:forward"]?.toString()?.let { parseLanesValue(it) }
+        val backwardValue = tags["lanes:backward"]?.toString()?.let { parseLanesValue(it) }
+
+        if (forwardValue != null || backwardValue != null) {
+            return (forwardValue ?: 0) + (backwardValue ?: 0)
+        }
+
+        // Step 3: Fallback to highway-based inference
+        tags[ALTERNATIVE_OSM_TAG]?.toString()?.let { highwayValue ->
+            return when (highwayValue) {
+                in HIGHWAY_FALLBACK_0_LANES -> 0
+                in HIGHWAY_FALLBACK_1_LANE -> 1
+                in HIGHWAY_FALLBACK_2_LANES -> 2
+                else -> 1
+            }
+        }
+
+        // Step 4: Ultimate fallback
+        return 1
+    }
+
+    /**
+     * Creates the back-mapping OSM tag for the given number of lanes.
+     *
+     * @param numberOfLanes The RadSim number of lanes value.
+     * @return The corresponding OSM tag, or null if the value should not be back-mapped.
+     */
+    @Suppress("unused") // Part of the API
+    fun backMappingTag(numberOfLanes: Int): OsmTag? {
+        return if (numberOfLanes >= 0) {
+            OsmTag("lanes", numberOfLanes.toString())
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/de/radsim/translation/model/NumberOfLanesCategory.kt
+++ b/src/main/kotlin/de/radsim/translation/model/NumberOfLanesCategory.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Cyface GmbH
+ *
+ * This file is part of the RadSim Translation Model.
+ *
+ *  The RadSim Translation Model is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The RadSim Translation Model is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the RadSim Translation Model.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.radsim.translation.model
+
+/**
+ * An enumeration providing the different number of lanes categories considered by RadSim.
+ *
+ * TODO: These categories are preliminary guesses. Update when TUD provides the final
+ *       coefficients and category definitions for numberOfLanes.
+ *
+ * The categories are:
+ * - 0 lanes: footways, cycleways, paths without motor vehicle lanes
+ * - 1 lane: single lane roads (residential, service, etc.)
+ * - 2 lanes: standard two-lane roads (TODO: reference category for selection model until we hear something from TUD)
+ * - 3+ lanes: multi-lane roads
+ *
+ * @property value The value for the RadSim number of lanes category tag
+ */
+enum class NumberOfLanesCategory(val value: String) {
+    /**
+     * Roads with no motor vehicle lanes (footways, cycleways, pedestrian paths).
+     */
+    LANES_0("0"),
+
+    /**
+     * Single lane roads (residential, service roads, tracks).
+     */
+    LANES_1("1"),
+
+    /**
+     * Standard two-lane roads (tertiary, secondary, primary).
+     * TODO: This is the reference category for the selection model until we hear something from TUD.
+     */
+    LANES_2("2"),
+
+    /**
+     * Multi-lane roads with 3 or more lanes.
+     */
+    LANES_3_OR_MORE("3ormore");
+
+    companion object {
+        /**
+         * Classifies a numeric lane count into a NumberOfLanesCategory.
+         *
+         * @param numberOfLanes The number of lanes as returned by [NumberOfLanes.toRadSim]
+         * @return The corresponding NumberOfLanesCategory
+         */
+        fun fromLaneCount(numberOfLanes: Int): NumberOfLanesCategory {
+            return when {
+                numberOfLanes <= 0 -> LANES_0
+                numberOfLanes == 1 -> LANES_1
+                numberOfLanes == 2 -> LANES_2
+                else -> LANES_3_OR_MORE
+            }
+        }
+
+        /**
+         * Parses a RadSim tag value and returns the corresponding NumberOfLanesCategory.
+         *
+         * @param value The RadSim tag value
+         * @return The corresponding NumberOfLanesCategory
+         */
+        fun fromValue(value: String): NumberOfLanesCategory =
+            entries.firstOrNull { it.value == value }
+                ?: error("Unexpected RadSim number of lanes category tag: $value")
+    }
+}

--- a/src/main/kotlin/de/radsim/translation/model/ToRadSimMapper.kt
+++ b/src/main/kotlin/de/radsim/translation/model/ToRadSimMapper.kt
@@ -46,6 +46,9 @@ class ToRadSimMapper(private val tags: List<OsmTag>) {
             else ->
                 originalTags[Speed.RADSIM_TAG] = Speed.NO_INFORMATION.value
         }
+
+        originalTags[NumberOfLanes.RADSIM_TAG] = NumberOfLanes.toRadSim(original).toString()
+
         return originalTags
     }
 }

--- a/src/test/kotlin/de/radsim/translation/model/NumberOfLanesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/NumberOfLanesTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2019-2024 Cyface GmbH
+ *
+ * This file is part of the RadSim Translation Model.
+ *
+ *  The RadSim Translation Model is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The RadSim Translation Model is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the RadSim Translation Model.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.radsim.translation.model
+
+import de.cyface.model.osm.OsmTag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class NumberOfLanesTest {
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    fun testToRadSim(parameter: NumberOfLanesParameters) {
+        // Arrange
+        val result = NumberOfLanes.toRadSim(parameter.osmTags)
+
+        // Assert
+        assert(result == parameter.expectedLanes) {
+            "Expected ${parameter.expectedLanes} lanes for tags ${parameter.osmTags}, but got $result"
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("backMappingParameters")
+    fun testBackMapping(parameter: BackMappingLanesParameters) {
+        // Arrange
+        // Act
+        val result = NumberOfLanes.backMappingTag(parameter.numberOfLanes)
+
+        // Assert
+        assert(result == parameter.osmTag) {
+            "Expected ${parameter.osmTag} for ${parameter.numberOfLanes} lanes, but got $result"
+        }
+    }
+
+    @Suppress("SpellCheckingInspection")
+    companion object {
+        /**
+         * @return All test setup to run
+         */
+        @JvmStatic
+        fun testParameters(): Stream<NumberOfLanesParameters> {
+            return Stream.of(
+                // Direct lanes tag
+                NumberOfLanesParameters(mapOf("lanes" to "1"), 1),
+                NumberOfLanesParameters(mapOf("lanes" to "2"), 2),
+                NumberOfLanesParameters(mapOf("lanes" to "3"), 3),
+                NumberOfLanesParameters(mapOf("lanes" to "4"), 4),
+                NumberOfLanesParameters(mapOf("lanes" to "6"), 6),
+
+                // lanes:forward and lanes:backward (sum)
+                NumberOfLanesParameters(mapOf("lanes:forward" to "1", "lanes:backward" to "1"), 2),
+                NumberOfLanesParameters(mapOf("lanes:forward" to "2", "lanes:backward" to "2"), 4),
+                NumberOfLanesParameters(mapOf("lanes:forward" to "3", "lanes:backward" to "1"), 4),
+                NumberOfLanesParameters(mapOf("lanes:forward" to "2"), 2),
+                NumberOfLanesParameters(mapOf("lanes:backward" to "3"), 3),
+
+                // Highway-based fallback: 0 lanes (no car access)
+                NumberOfLanesParameters(mapOf("highway" to "footway"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "steps"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "cycleway"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "pedestrian"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "platform"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "elevator"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "bridleway"), 0),
+                NumberOfLanesParameters(mapOf("highway" to "bus_stop"), 0),
+
+                // Highway-based fallback: 1 lane
+                NumberOfLanesParameters(mapOf("highway" to "track"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "path"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "service"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "residential"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "living_street"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "unclassified"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "construction"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "proposed"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "rest_area"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "raceway"), 1),
+
+                // Highway-based fallback: 1 lane (link roads)
+                NumberOfLanesParameters(mapOf("highway" to "tertiary_link"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "secondary_link"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "primary_link"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "trunk_link"), 1),
+
+                // Highway-based fallback: 2 lanes
+                NumberOfLanesParameters(mapOf("highway" to "tertiary"), 2),
+                NumberOfLanesParameters(mapOf("highway" to "secondary"), 2),
+                NumberOfLanesParameters(mapOf("highway" to "primary"), 2),
+
+                // Default fallback: 1 lane for unknown highway types
+                NumberOfLanesParameters(mapOf("highway" to "motorway"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "trunk"), 1),
+                NumberOfLanesParameters(mapOf("highway" to "motorway_link"), 1),
+
+                // Ultimate fallback: 1 lane when no relevant tags
+                NumberOfLanesParameters(mapOf(), 1),
+                NumberOfLanesParameters(mapOf("surface" to "asphalt"), 1),
+
+                // Hierarchical priority tests: lanes tag takes priority over everything
+                NumberOfLanesParameters(
+                    mapOf("lanes" to "4", "highway" to "footway"),
+                    4
+                ),
+                NumberOfLanesParameters(
+                    mapOf("lanes" to "3", "lanes:forward" to "1", "lanes:backward" to "1"),
+                    3
+                ),
+                NumberOfLanesParameters(
+                    mapOf("lanes" to "2", "highway" to "primary"),
+                    2
+                ),
+
+                // Hierarchical priority: lanes:forward/backward takes priority over highway
+                NumberOfLanesParameters(
+                    mapOf("lanes:forward" to "3", "lanes:backward" to "2", "highway" to "footway"),
+                    5
+                ),
+                NumberOfLanesParameters(
+                    mapOf("lanes:forward" to "1", "highway" to "primary"),
+                    1
+                ),
+
+                // Edge case: invalid lanes value should fall back
+                NumberOfLanesParameters(
+                    mapOf("lanes" to "invalid", "highway" to "tertiary"),
+                    2
+                ),
+                NumberOfLanesParameters(
+                    mapOf("lanes" to "invalid", "lanes:forward" to "2"),
+                    2
+                ),
+            )
+        }
+
+        @JvmStatic
+        fun backMappingParameters(): Stream<BackMappingLanesParameters> {
+            return Stream.of(
+                BackMappingLanesParameters(0, OsmTag("lanes", "0")),
+                BackMappingLanesParameters(1, OsmTag("lanes", "1")),
+                BackMappingLanesParameters(2, OsmTag("lanes", "2")),
+                BackMappingLanesParameters(3, OsmTag("lanes", "3")),
+                BackMappingLanesParameters(4, OsmTag("lanes", "4")),
+                BackMappingLanesParameters(-1, null),
+            )
+        }
+    }
+}
+
+class NumberOfLanesParameters(
+    val osmTags: Map<String, Any>,
+    val expectedLanes: Int,
+)
+
+class BackMappingLanesParameters(
+    val numberOfLanes: Int,
+    val osmTag: OsmTag?,
+)

--- a/src/test/kotlin/de/radsim/translation/model/NumberOfLanesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/NumberOfLanesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Cyface GmbH
+ * Copyright (C) 2026 Cyface GmbH
  *
  * This file is part of the RadSim Translation Model.
  *


### PR DESCRIPTION
Implement hierarchical mapping from OSM lanes tags to RadSim noOfLanes attribute. The mapping checks lanes tag first, then sums lanes:forward and lanes:backward, and finally falls back to highway-based defaults.