### PR TITLE
[BIK-1558] Add land use model definitions

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/LandUse.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUse.kt
@@ -33,6 +33,11 @@ package de.radsim.translation.model
  *
  * Each way receives a binary value (0 or 1) for each category based on whether >= 50% of its
  * length falls within buffered polygons of that category.
+ *
+ * NOTE: This binary value is just an intermediate implementation. This treats a segment in the land-use case
+ * similar to other attributes, e.g. "either it is a cycle way or not". TUD will eventually change this to calculate
+ * the actual share of the edge which is "inside the land-use buffer area". But the coefficients will stay the same
+ * in the SelectionModel. Until we get a note from TUD, this binary decision stays as it is.
  */
 object LandUse {
     /**

--- a/src/main/kotlin/de/radsim/translation/model/LandUse.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUse.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Cyface GmbH
+ *
+ * This file is part of the RadSim Translation Model.
+ *
+ *  The RadSim Translation Model is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The RadSim Translation Model is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the RadSim Translation Model.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.radsim.translation.model
+
+/**
+ * Constants and utilities for land use feature mapping.
+ *
+ * Unlike other RadSim features (NumberOfLanes, BikeInfrastructure), land use is not derived
+ * from way tags. It requires spatial intersection with polygon geometries. Ways are annotated
+ * with binary land use attributes during RoadNetworkProcessing based on proximity to land use
+ * polygons.
+ *
+ * The three land use categories represent different types of environment:
+ * - Water: Rivers, lakes, basins
+ * - Green: Forests, parks, grass areas
+ * - Natural: Agricultural land, meadows, orchards
+ *
+ * Each way receives a binary value (0 or 1) for each category based on whether >= 50% of its
+ * length falls within buffered polygons of that category.
+ */
+object LandUse {
+    /**
+     * RadSim tag for water proximity (binary: 0 or 1).
+     *
+     * Set to 1 if >= 50% of the way length is within buffered water polygons.
+     */
+    const val RADSIM_TAG_WATER = "radsim_lu_is_near_water"
+
+    /**
+     * RadSim tag for green space proximity (binary: 0 or 1).
+     *
+     * Set to 1 if >= 50% of the way length is within buffered green space polygons.
+     */
+    const val RADSIM_TAG_GREEN = "radsim_lu_is_near_green"
+
+    /**
+     * RadSim tag for natural/agricultural proximity (binary: 0 or 1).
+     *
+     * Set to 1 if >= 50% of the way length is within buffered natural/agricultural polygons.
+     */
+    const val RADSIM_TAG_NATURAL = "radsim_lu_is_near_natural"
+
+    /**
+     * All land use RadSim tags.
+     */
+    val ALL_TAGS = listOf(RADSIM_TAG_WATER, RADSIM_TAG_GREEN, RADSIM_TAG_NATURAL)
+
+    /**
+     * Threshold percentage for binary classification.
+     *
+     * A way is classified as "near" a land use type if >= 50% of its length
+     * falls within buffered polygons of that type.
+     */
+    const val THRESHOLD_PERCENTAGE = 50.0
+
+    /**
+     * Converts a percentage overlap to binary classification.
+     *
+     * @param percentageOverlap The percentage of way length within buffered polygon (0-100)
+     * @return 1 if >= THRESHOLD_PERCENTAGE (50%), 0 otherwise
+     */
+    fun toBinary(percentageOverlap: Double): Int {
+        return if (percentageOverlap >= THRESHOLD_PERCENTAGE) 1 else 0
+    }
+
+    /**
+     * Gets the default value for a land use attribute when no polygon data is available.
+     *
+     * @return 0 (not near any land use type)
+     */
+    fun defaultValue(): Int = 0
+}

--- a/src/main/kotlin/de/radsim/translation/model/LandUse.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUse.kt
@@ -59,7 +59,7 @@ object LandUse {
     /**
      * All land use RadSim tags.
      */
-    val ALL_TAGS = listOf(RADSIM_TAG_WATER, RADSIM_TAG_GREEN, RADSIM_TAG_NATURAL)
+    // val ALL_TAGS = listOf(RADSIM_TAG_WATER, RADSIM_TAG_GREEN, RADSIM_TAG_NATURAL)
 
     /**
      * Threshold percentage for binary classification.
@@ -75,14 +75,8 @@ object LandUse {
      * @param percentageOverlap The percentage of way length within buffered polygon (0-100)
      * @return 1 if >= THRESHOLD_PERCENTAGE (50%), 0 otherwise
      */
+    @Suppress("unused") // Part of the API
     fun toBinary(percentageOverlap: Double): Int {
         return if (percentageOverlap >= THRESHOLD_PERCENTAGE) 1 else 0
     }
-
-    /**
-     * Gets the default value for a land use attribute when no polygon data is available.
-     *
-     * @return 0 (not near any land use type)
-     */
-    fun defaultValue(): Int = 0
 }

--- a/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
@@ -25,126 +25,43 @@ package de.radsim.translation.model
  * Ways are then annotated with binary attributes indicating whether they are "near" (>= 50%
  * of length within buffer) each land use type.
  *
- * These filters match the Python reference implementation (compute_landuse notebook).
+ * These filters match the Python reference implementation (compute_land-use notebook).
  *
  * @property value The value identifier for this land use category
  * @property radsimTag The RadSim tag name used to store the binary attribute on ways
- * @property osmFilters The OSM tag combinations used to identify features of this category.
- *           Note: Actual osmium filter expressions (with a/, w/ prefixes) are in NetworkExtractor.
  */
 enum class LandUseCategory(
     val value: String,
     val radsimTag: String,
-    val osmFilters: List<String>
 ) {
     /**
-     * Water features: water bodies, wetlands, basins, rivers, streams.
-     *
-     * Areas: natural=water/wetland/bay/strait, landuse=reservoir/basin/aquaculture,
-     *        waterway=riverbank/canal/ditch/drain/stream
-     * Lines: waterway=river/stream/canal/riverbank
+     * Water features like water bodies, wetlands, basins, rivers, streams.
      *
      * Buffer: 5-100m based on area and type (rivers get 100m).
      */
     WATER(
         "water",
         LandUse.RADSIM_TAG_WATER,
-        listOf(
-            // Areas (natural)
-            "natural=water",
-            "natural=wetland",
-            "natural=bay",
-            "natural=strait",
-            // Areas (landuse)
-            "landuse=reservoir",
-            "landuse=basin",
-            "landuse=aquaculture",
-            // Areas (waterway)
-            "waterway=riverbank",
-            "waterway=canal",
-            "waterway=ditch",
-            "waterway=drain",
-            "waterway=stream",
-            // Lines (waterway)
-            "waterway=river"
-        )
     ),
 
     /**
-     * Green spaces: forests, meadows, parks, gardens, natural vegetation.
-     *
-     * Areas: landuse=forest/meadow/grass/greenfield/village_green,
-     *        natural=wood/grassland/heath/scrub,
-     *        leisure=park/garden/golf_course/pitch/playground,
-     *        amenity=grave_yard, boundary=national_park/protected_area
-     * Lines: natural=hedge/tree_row
+     * Green spaces like forests, meadows, parks, gardens, natural vegetation.
      *
      * Buffer: 5-20m based on area.
      */
     GREEN(
         "green",
         LandUse.RADSIM_TAG_GREEN,
-        listOf(
-            // Areas (landuse)
-            "landuse=forest",
-            "landuse=meadow",
-            "landuse=grass",
-            "landuse=greenfield",
-            "landuse=village_green",
-            // Areas (natural)
-            "natural=wood",
-            "natural=grassland",
-            "natural=heath",
-            "natural=scrub",
-            // Areas (leisure)
-            "leisure=park",
-            "leisure=garden",
-            "leisure=golf_course",
-            "leisure=pitch",
-            "leisure=playground",
-            // Areas (other)
-            "amenity=grave_yard",
-            "boundary=national_park",
-            "boundary=protected_area",
-            // Lines (natural)
-            "natural=hedge",
-            "natural=tree_row"
-        )
     ),
 
     /**
-     * Natural/agricultural areas: farmland, orchards, vineyards, greenhouses.
-     *
-     * Areas: landuse=farmland/farmyard/orchard/vineyard/plant_nursery/greenhouse_horticulture,
-     *        crop=* (any value), meadow=agricultural/pasture/hay,
-     *        natural=grassland, building=farm/greenhouse
-     * Lines: landuse=farmland/farmyard/orchard/vineyard/plant_nursery/greenhouse_horticulture
+     * Natural/agricultural areas like farmland, orchards, vineyards, greenhouses.
      *
      * Buffer: 5-30m based on area.
      */
     NATURAL(
         "natural",
         LandUse.RADSIM_TAG_NATURAL,
-        listOf(
-            // Areas (landuse)
-            "landuse=farmland",
-            "landuse=farmyard",
-            "landuse=orchard",
-            "landuse=vineyard",
-            "landuse=plant_nursery",
-            "landuse=greenhouse_horticulture",
-            // Areas (crop - any value)
-            "crop=*",
-            // Areas (meadow key with specific values)
-            "meadow=agricultural",
-            "meadow=pasture",
-            "meadow=hay",
-            // Areas (natural)
-            "natural=grassland",
-            // Areas (building)
-            "building=farm",
-            "building=greenhouse"
-        )
     );
 
     companion object {

--- a/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 Cyface GmbH
+ *
+ * This file is part of the RadSim Translation Model.
+ *
+ *  The RadSim Translation Model is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The RadSim Translation Model is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the RadSim Translation Model.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.radsim.translation.model
+
+/**
+ * An enumeration providing the different land use categories considered by RadSim.
+ *
+ * Land use polygons are extracted from OSM data and buffered based on their category and area.
+ * Ways are then annotated with binary attributes indicating whether they are "near" (>= 50%
+ * of length within buffer) each land use type.
+ *
+ * TODO: Land use categories are placeholders - update when TUD provides final categories
+ *
+ * @property value The value identifier for this land use category
+ * @property radsimTag The RadSim tag name used to store the binary attribute on ways
+ * @property osmFilters The osmium tags-filter expressions to extract relevant polygons from PBF
+ */
+enum class LandUseCategory(
+    val value: String,
+    val radsimTag: String,
+    val osmFilters: List<String>
+) {
+    /**
+     * Water features: rivers, lakes, basins.
+     *
+     * Buffer: 5-100m based on area and type (rivers get 100m).
+     */
+    WATER(
+        "water",
+        LandUse.RADSIM_TAG_WATER,
+        // TODO: OSM filters are placeholders - update when TUD provides final tag list
+        listOf(
+            "landuse=basin",
+            "natural=water",
+            "waterway=river",
+            "waterway=stream",
+            "waterway=canal"
+        )
+    ),
+
+    /**
+     * Green spaces: forests, parks, grass areas.
+     *
+     * Buffer: 5-20m based on area.
+     */
+    GREEN(
+        "green",
+        LandUse.RADSIM_TAG_GREEN,
+        // TODO: OSM filters are placeholders - update when TUD provides final tag list
+        listOf(
+            "landuse=forest",
+            "landuse=grass",
+            "leisure=park",
+            "natural=wood"
+        )
+    ),
+
+    /**
+     * Natural/agricultural areas: farmland, meadows, orchards.
+     *
+     * Buffer: 5-30m based on area.
+     */
+    NATURAL(
+        "natural",
+        LandUse.RADSIM_TAG_NATURAL,
+        // TODO: OSM filters are placeholders - update when TUD provides final tag list
+        listOf(
+            "landuse=farmland",
+            "landuse=meadow",
+            "landuse=orchard"
+        )
+    );
+
+    companion object {
+        /**
+         * Returns the land use category for a given value string.
+         *
+         * @param value The category value string
+         * @return The corresponding LandUseCategory
+         * @throws IllegalStateException if the value is not recognized
+         */
+        fun fromValue(value: String): LandUseCategory =
+            entries.firstOrNull { it.value == value }
+                ?: error("Unexpected RadSim land use category: $value")
+
+        /**
+         * Returns the land use category for a given RadSim tag name.
+         *
+         * @param tag The RadSim tag name
+         * @return The corresponding LandUseCategory
+         * @throws IllegalStateException if the tag is not recognized
+         */
+        fun fromRadsimTag(tag: String): LandUseCategory =
+            entries.firstOrNull { it.radsimTag == tag }
+                ?: error("Unexpected RadSim land use tag: $tag")
+
+        // TODO: Buffer calculations are placeholders - update when TUD provides final values
+
+        /**
+         * Calculates buffer size for water features based on area and type.
+         *
+         * Rivers get a larger buffer (100m) as they are linear features.
+         * Lakes and other water bodies are buffered based on their area.
+         *
+         * @param areaSquareMeters The polygon area in square meters
+         * @param isRiver Whether this is a river (linear waterway)
+         * @return Buffer distance in meters
+         */
+        @Suppress("MagicNumber")
+        fun waterBufferMeters(areaSquareMeters: Double, isRiver: Boolean): Double {
+            if (isRiver) return 100.0
+            return when {
+                areaSquareMeters < 100 -> 5.0      // Very small ponds
+                areaSquareMeters < 1000 -> 20.0   // Small lakes
+                areaSquareMeters < 10000 -> 50.0  // Medium lakes
+                else -> 100.0                      // Large lakes
+            }
+        }
+
+        /**
+         * Calculates buffer size for green features based on area.
+         *
+         * @param areaSquareMeters The polygon area in square meters
+         * @return Buffer distance in meters
+         */
+        @Suppress("MagicNumber")
+        fun greenBufferMeters(areaSquareMeters: Double): Double {
+            return when {
+                areaSquareMeters < 50 -> 5.0
+                areaSquareMeters < 500 -> 10.0
+                else -> 20.0
+            }
+        }
+
+        /**
+         * Calculates buffer size for natural/agriculture features based on area.
+         *
+         * @param areaSquareMeters The polygon area in square meters
+         * @return Buffer distance in meters
+         */
+        @Suppress("MagicNumber")
+        fun naturalBufferMeters(areaSquareMeters: Double): Double {
+            return when {
+                areaSquareMeters < 200 -> 5.0
+                areaSquareMeters < 2000 -> 15.0
+                else -> 30.0
+            }
+        }
+
+        /**
+         * Calculates the appropriate buffer for a polygon based on its category and area.
+         *
+         * @param category The land use category
+         * @param areaSquareMeters The polygon area in square meters
+         * @param isRiver Whether this is a river (only applicable for WATER category)
+         * @return Buffer distance in meters
+         */
+        fun bufferMeters(category: LandUseCategory, areaSquareMeters: Double, isRiver: Boolean = false): Double {
+            return when (category) {
+                WATER -> waterBufferMeters(areaSquareMeters, isRiver)
+                GREEN -> greenBufferMeters(areaSquareMeters)
+                NATURAL -> naturalBufferMeters(areaSquareMeters)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
@@ -21,15 +21,16 @@ package de.radsim.translation.model
 /**
  * An enumeration providing the different land use categories considered by RadSim.
  *
- * Land use polygons are extracted from OSM data and buffered based on their category and area.
+ * Land use polygons and lines are extracted from OSM data and buffered based on their category and area.
  * Ways are then annotated with binary attributes indicating whether they are "near" (>= 50%
  * of length within buffer) each land use type.
  *
- * TODO: Land use categories are placeholders - update when TUD provides final categories
+ * These filters match the Python reference implementation (compute_landuse notebook).
  *
  * @property value The value identifier for this land use category
  * @property radsimTag The RadSim tag name used to store the binary attribute on ways
- * @property osmFilters The osmium tags-filter expressions to extract relevant polygons from PBF
+ * @property osmFilters The OSM tag combinations used to identify features of this category.
+ *           Note: Actual osmium filter expressions (with a/, w/ prefixes) are in NetworkExtractor.
  */
 enum class LandUseCategory(
     val value: String,
@@ -37,53 +38,112 @@ enum class LandUseCategory(
     val osmFilters: List<String>
 ) {
     /**
-     * Water features: rivers, lakes, basins.
+     * Water features: water bodies, wetlands, basins, rivers, streams.
+     *
+     * Areas: natural=water/wetland/bay/strait, landuse=reservoir/basin/aquaculture,
+     *        waterway=riverbank/canal/ditch/drain/stream
+     * Lines: waterway=river/stream/canal/riverbank
      *
      * Buffer: 5-100m based on area and type (rivers get 100m).
      */
     WATER(
         "water",
         LandUse.RADSIM_TAG_WATER,
-        // TODO: OSM filters are placeholders - update when TUD provides final tag list
         listOf(
-            "landuse=basin",
+            // Areas (natural)
             "natural=water",
-            "waterway=river",
+            "natural=wetland",
+            "natural=bay",
+            "natural=strait",
+            // Areas (landuse)
+            "landuse=reservoir",
+            "landuse=basin",
+            "landuse=aquaculture",
+            // Areas (waterway)
+            "waterway=riverbank",
+            "waterway=canal",
+            "waterway=ditch",
+            "waterway=drain",
             "waterway=stream",
-            "waterway=canal"
+            // Lines (waterway)
+            "waterway=river"
         )
     ),
 
     /**
-     * Green spaces: forests, parks, grass areas.
+     * Green spaces: forests, meadows, parks, gardens, natural vegetation.
+     *
+     * Areas: landuse=forest/meadow/grass/greenfield/village_green,
+     *        natural=wood/grassland/heath/scrub,
+     *        leisure=park/garden/golf_course/pitch/playground,
+     *        amenity=grave_yard, boundary=national_park/protected_area
+     * Lines: natural=hedge/tree_row
      *
      * Buffer: 5-20m based on area.
      */
     GREEN(
         "green",
         LandUse.RADSIM_TAG_GREEN,
-        // TODO: OSM filters are placeholders - update when TUD provides final tag list
         listOf(
+            // Areas (landuse)
             "landuse=forest",
+            "landuse=meadow",
             "landuse=grass",
+            "landuse=greenfield",
+            "landuse=village_green",
+            // Areas (natural)
+            "natural=wood",
+            "natural=grassland",
+            "natural=heath",
+            "natural=scrub",
+            // Areas (leisure)
             "leisure=park",
-            "natural=wood"
+            "leisure=garden",
+            "leisure=golf_course",
+            "leisure=pitch",
+            "leisure=playground",
+            // Areas (other)
+            "amenity=grave_yard",
+            "boundary=national_park",
+            "boundary=protected_area",
+            // Lines (natural)
+            "natural=hedge",
+            "natural=tree_row"
         )
     ),
 
     /**
-     * Natural/agricultural areas: farmland, meadows, orchards.
+     * Natural/agricultural areas: farmland, orchards, vineyards, greenhouses.
+     *
+     * Areas: landuse=farmland/farmyard/orchard/vineyard/plant_nursery/greenhouse_horticulture,
+     *        crop=* (any value), meadow=agricultural/pasture/hay,
+     *        natural=grassland, building=farm/greenhouse
+     * Lines: landuse=farmland/farmyard/orchard/vineyard/plant_nursery/greenhouse_horticulture
      *
      * Buffer: 5-30m based on area.
      */
     NATURAL(
         "natural",
         LandUse.RADSIM_TAG_NATURAL,
-        // TODO: OSM filters are placeholders - update when TUD provides final tag list
         listOf(
+            // Areas (landuse)
             "landuse=farmland",
-            "landuse=meadow",
-            "landuse=orchard"
+            "landuse=farmyard",
+            "landuse=orchard",
+            "landuse=vineyard",
+            "landuse=plant_nursery",
+            "landuse=greenhouse_horticulture",
+            // Areas (crop - any value)
+            "crop=*",
+            // Areas (meadow key with specific values)
+            "meadow=agricultural",
+            "meadow=pasture",
+            "meadow=hay",
+            // Areas (natural)
+            "natural=grassland",
+            // Areas (building)
+            "building=farm",
+            "building=greenhouse"
         )
     );
 
@@ -110,7 +170,7 @@ enum class LandUseCategory(
             entries.firstOrNull { it.radsimTag == tag }
                 ?: error("Unexpected RadSim land use tag: $tag")
 
-        // TODO: Buffer calculations are placeholders - update when TUD provides final values
+        // Buffer calculations match the Python reference implementation (compute_landuse notebook)
 
         /**
          * Calculates buffer size for water features based on area and type.

--- a/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
+++ b/src/main/kotlin/de/radsim/translation/model/LandUseCategory.kt
@@ -126,10 +126,10 @@ enum class LandUseCategory(
         fun waterBufferMeters(areaSquareMeters: Double, isRiver: Boolean): Double {
             if (isRiver) return 100.0
             return when {
-                areaSquareMeters < 100 -> 5.0      // Very small ponds
-                areaSquareMeters < 1000 -> 20.0   // Small lakes
-                areaSquareMeters < 10000 -> 50.0  // Medium lakes
-                else -> 100.0                      // Large lakes
+                areaSquareMeters < 100 -> 5.0 // Very small ponds
+                areaSquareMeters < 1000 -> 20.0 // Small lakes
+                areaSquareMeters < 10000 -> 50.0 // Medium lakes
+                else -> 100.0 // Large lakes
             }
         }
 
@@ -171,6 +171,7 @@ enum class LandUseCategory(
          * @param isRiver Whether this is a river (only applicable for WATER category)
          * @return Buffer distance in meters
          */
+        @Suppress("unused") // Part of the API
         fun bufferMeters(category: LandUseCategory, areaSquareMeters: Double, isRiver: Boolean = false): Double {
             return when (category) {
                 WATER -> waterBufferMeters(areaSquareMeters, isRiver)


### PR DESCRIPTION
Add LandUse constants for binary land use attributes (water, green, natural) with 50% threshold classification. Add LandUseCategory enum with OSM filter expressions and buffer calculations.