### PR TITLE
Fix back-mapping stall for all ways with access=no

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
@@ -278,14 +278,15 @@ enum class BikeInfrastructure(
             // Validate that we're receiving OSM tags, not RadSim tags [BIK-1478]
             TagFormatValidator.requireOsmFormat(tags, "BikeInfrastructure.toRadSim()")
 
+            // Explicit infrastructure designations take priority over access restrictions
+            if (isCycleHighway(tags)) return CYCLE_HIGHWAY
+            if (isBikeRoad(tags)) return BICYCLE_ROAD
+
             if ((tags.containsKey(OsmTag.ACCESS.key) && isNotAccessible(tags)) ||
                 (tags.containsKey(OsmTag.TRAM.key) && tags[OsmTag.TRAM.key] == OsmValue.YES.value)
             ) {
                 return NO // unpacked from `service`
             }
-
-            if (isCycleHighway(tags)) return CYCLE_HIGHWAY
-            if (isBikeRoad(tags)) return BICYCLE_ROAD
             if (isService(tags)) return SERVICE_MISC
 
             if (bicycleWayRight(tags)) {

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -51,6 +51,29 @@ class BackMappingMatrixTest {
         }
     }
 
+    @Test
+    fun `NO to CYCLE_HIGHWAY should not stall when way has access=no`() {
+        // All 89 stalls from bulk back-mapping test had access=no. The access=no check in
+        // toRadSim() returned NO before reaching isCycleHighway(), so adding cycle_highway=yes
+        // didn't change the classification.
+        val accessNoTags = mapOf(
+            "highway" to "service",
+            "access" to "no",
+            "@id" to "1420897",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+
+        assertDoesNotThrow {
+            RadSimDeltaEngine.computeDelta(
+                currentTags = accessNoTags,
+                key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                value = SimplifiedBikeInfrastructure.CYCLE_HIGHWAY.value
+            )
+        }
+    }
+
     @TestFactory
     fun `all infrastructure combinations should back-map without recursion or stall`(): List<DynamicTest> {
         val values = SimplifiedBikeInfrastructure.entries


### PR DESCRIPTION
isCycleHighway/isBikeRoad checks must precede the access=no early return in toRadSim(). Otherwise adding cycle_highway=yes to an access=no way still classifies as NO, causing a stall. Fixes all 89 stalls found in bulk back-mapping test.