### PR TITLE
[BIK-1376] Set highway=cycleway in back-mapping for new ways

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -33,19 +33,17 @@ object BackMappingRules {
         RuleKey(NO, BICYCLE_ROAD) to { _ ->
             setOf(OsmTag("highway", "residential"), OsmTag("bicycle_road", "yes"))
         },
-        RuleKey(NO, CYCLE_HIGHWAY) to { tags ->
-            // Added, even though this is not a way tags (cycle_highway)
-            val highway = tags["highway"] as? String
-            val maybeHighwayChange = if (highway == "service") {
-                setOf(OsmTag("highway", "cycleway"))
-            } else {
-                emptySet()
-            }
-            maybeHighwayChange + OsmTag("cycle_highway", "yes")
+        RuleKey(NO, CYCLE_HIGHWAY) to { _ ->
+            setOf(OsmTag("highway", "cycleway"), OsmTag("cycle_highway", "yes"))
         },
         // R19
         RuleKey(NO, BICYCLE_WAY) to { _ ->
-            setOf(OsmTag("bicycle", "designated"), OsmTag("foot", "designated"), OsmTag("segregated", "yes"))
+            setOf(
+                OsmTag("highway", "cycleway"),
+                OsmTag("bicycle", "designated"),
+                OsmTag("foot", "designated"),
+                OsmTag("segregated", "yes"),
+            )
         },
         // R20
         RuleKey(NO, BICYCLE_LANE) to { _ ->
@@ -232,11 +230,12 @@ object BackMappingRules {
         // CYCLE_HIGHWAY → others (R2–R7)
         // -------------------------------------------------------------------
         RuleKey(CYCLE_HIGHWAY, BICYCLE_ROAD) to { tags ->
-            val highway = tags["highway"] ?: "residential"
+            val highway = tags["highway"] as? String
+            val targetHighway = if (highway == null || highway == "cycleway") "residential" else highway
             setOf(
-                OsmTag("highway", highway),
+                OsmTag("highway", targetHighway),
                 OsmTag("bicycle_road", "yes"),
-                OsmTag("cycle_highway", ""), // Added, even though this is not a way tags
+                OsmTag("cycle_highway", ""),
             )
         },
 

--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -37,6 +37,10 @@ object BackMappingRules {
             setOf(OsmTag("highway", "cycleway"), OsmTag("cycle_highway", "yes"))
         },
         // R19
+        // TODO: Consider also producing smoothness=excellent for Comfort1 surfaces, so new ways
+        //  can compete with existing ones that typically have smoothness tags. Currently smoothness
+        //  only affects GH speed (not priority) and the custom model caps speed at 15, so no
+        //  practical impact yet — but would matter if the speed cap is removed. [BIK-1376]
         RuleKey(NO, BICYCLE_WAY) to { _ ->
             setOf(
                 OsmTag("highway", "cycleway"),

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -106,7 +106,7 @@ class BackMappingMatrixTest {
                 mapOf("bicycle_road" to "yes")
 
             SimplifiedBikeInfrastructure.CYCLE_HIGHWAY ->
-                mapOf("cycle_highway" to "yes")
+                mapOf("highway" to "cycleway", "cycle_highway" to "yes")
 
             SimplifiedBikeInfrastructure.BICYCLE_WAY ->
                 mapOf("highway" to "cycleway") // generic bike_way signature

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -122,6 +122,7 @@ class BackMappingRulesTest {
     @Test
     fun `R19 - no to bicycle_way`() {
         val expected = tags(
+            "highway" to "cycleway",
             "bicycle" to "designated",
             "foot" to "designated",
             "segregated" to "yes"
@@ -188,7 +189,7 @@ class BackMappingRulesTest {
 
     @Test
     fun `NO to CYCLE_HIGHWAY - without service road`() {
-        val expected = tags("cycle_highway" to "yes")
+        val expected = tags("highway" to "cycleway", "cycle_highway" to "yes")
         val actual = BackMappingRules.applyRule(
             SimplifiedBikeInfrastructure.NO,
             SimplifiedBikeInfrastructure.CYCLE_HIGHWAY,

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -188,6 +188,36 @@ class BackMappingRulesTest {
     }
 
     @Test
+    fun `CYCLE_HIGHWAY to BICYCLE_ROAD - replaces cycleway with residential`() {
+        val expected = tags(
+            "highway" to "residential",
+            "bicycle_road" to "yes",
+            "cycle_highway" to "",
+        )
+        val actual = BackMappingRules.applyRule(
+            SimplifiedBikeInfrastructure.CYCLE_HIGHWAY,
+            SimplifiedBikeInfrastructure.BICYCLE_ROAD,
+            mapOf("highway" to "cycleway", "cycle_highway" to "yes")
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `CYCLE_HIGHWAY to BICYCLE_ROAD - preserves non-cycleway highway`() {
+        val expected = tags(
+            "highway" to "tertiary",
+            "bicycle_road" to "yes",
+            "cycle_highway" to "",
+        )
+        val actual = BackMappingRules.applyRule(
+            SimplifiedBikeInfrastructure.CYCLE_HIGHWAY,
+            SimplifiedBikeInfrastructure.BICYCLE_ROAD,
+            mapOf("highway" to "tertiary", "cycle_highway" to "yes")
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `NO to CYCLE_HIGHWAY - without service road`() {
         val expected = tags("highway" to "cycleway", "cycle_highway" to "yes")
         val actual = BackMappingRules.applyRule(

--- a/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
@@ -36,7 +36,7 @@ class SimplifiedBikeInfrastructureTest {
     @Test
     fun `NO to CycleHighway should set cycle_highway tag`() {
         val result = applyBackMap(SimplifiedBikeInfrastructure.CYCLE_HIGHWAY)
-        assertEquals(setOf(OsmTag("cycle_highway", "yes")), result)
+        assertEquals(setOf(OsmTag("highway", "cycleway"), OsmTag("cycle_highway", "yes")), result)
     }
 
     @Test
@@ -97,7 +97,7 @@ class SimplifiedBikeInfrastructureTest {
     @Test
     fun `BusLane to CycleHighway should only add cycle_highway tag`() {
         val result = applyBackMap(SimplifiedBikeInfrastructure.CYCLE_HIGHWAY)
-        assertEquals(setOf(OsmTag("cycle_highway", "yes")), result)
+        assertEquals(setOf(OsmTag("highway", "cycleway"), OsmTag("cycle_highway", "yes")), result)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Back-mapping for NO -> BICYCLE_WAY (R19) now produces `highway=cycleway` in the delta, so new bicycle ways get the correct highway tag in the PBF for GraphHopper routing and correct feature vector classification in the simulation
- Back-mapping for NO -> CYCLE_HIGHWAY simplified to always set `highway=cycleway` (previously only did so for service roads)
- CYCLE_HIGHWAY -> BICYCLE_ROAD now maps `highway=cycleway` to `highway=residential` to avoid the semantically incorrect combination `highway=cycleway, bicycle_road=yes`
- Added TODO noting that `smoothness=excellent` back-mapping for Comfort1 surfaces could be considered in the future

## Test plan
- [x] Existing tests updated to match new expected output
- [x] New tests added for CYCLE_HIGHWAY -> BICYCLE_ROAD transition (both cycleway-to-residential replacement and preservation of other highway values)
- [x] BackMappingMatrixTest updated with correct minimal context for CYCLE_HIGHWAY
- [x] Full build passes (`./gradlew clean test detekt`)