### PR TITLE
[BIK-2058] Fix back-mapping stall for cycleway infra

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -106,7 +106,8 @@ object BackMappingRules {
             setOf(
                 OsmTag("bicycle_road", ""), // R2: remove
                 OsmTag("highway", "path"), // R7
-                OsmTag("bicycle", "") // R7
+                OsmTag("bicycle", ""), // R7
+                OsmTag("cycleway", ""),
             )
         },
         RuleKey(BICYCLE_ROAD, CYCLE_HIGHWAY) to { _ ->
@@ -135,7 +136,7 @@ object BackMappingRules {
             }
         },
         RuleKey(BICYCLE_WAY, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
         },
         RuleKey(BICYCLE_WAY, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -224,7 +225,7 @@ object BackMappingRules {
             setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "share_busway"))
         },
         RuleKey(MIXED_WAY, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
         },
         RuleKey(MIXED_WAY, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -283,6 +284,7 @@ object BackMappingRules {
             setOf(
                 OsmTag("highway", "path"),
                 OsmTag("bicycle", ""),
+                OsmTag("cycleway", ""),
                 OsmTag("cycle_highway", ""), // Added, even though this is not a way tags
             )
         },

--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -164,7 +164,7 @@ object BackMappingRules {
             )
         },
         RuleKey(BICYCLE_LANE, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
         },
         RuleKey(BICYCLE_LANE, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -195,7 +195,7 @@ object BackMappingRules {
             ) // R13
         },
         RuleKey(BUS_LANE, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
         },
         RuleKey(BUS_LANE, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags

--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -24,6 +24,13 @@ object BackMappingRules {
         val to: SimplifiedBikeInfrastructure
     )
 
+    private val REMOVE_CYCLEWAY_TAGS = setOf(
+        OsmTag("cycleway", ""),
+        OsmTag("cycleway:right", ""),
+        OsmTag("cycleway:left", ""),
+        OsmTag("cycleway:both", ""),
+    )
+
     private val rules: Map<RuleKey, (Map<String, Any>) -> Set<OsmTag>> = mapOf(
 
         // -------------------------------------------------------------------
@@ -107,8 +114,7 @@ object BackMappingRules {
                 OsmTag("bicycle_road", ""), // R2: remove
                 OsmTag("highway", "path"), // R7
                 OsmTag("bicycle", ""), // R7
-                OsmTag("cycleway", ""),
-            )
+            ) + REMOVE_CYCLEWAY_TAGS
         },
         RuleKey(BICYCLE_ROAD, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -136,7 +142,7 @@ object BackMappingRules {
             }
         },
         RuleKey(BICYCLE_WAY, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) + REMOVE_CYCLEWAY_TAGS // R7
         },
         RuleKey(BICYCLE_WAY, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -165,7 +171,7 @@ object BackMappingRules {
             )
         },
         RuleKey(BICYCLE_LANE, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) + REMOVE_CYCLEWAY_TAGS // R7
         },
         RuleKey(BICYCLE_LANE, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -196,7 +202,7 @@ object BackMappingRules {
             ) // R13
         },
         RuleKey(BUS_LANE, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) + REMOVE_CYCLEWAY_TAGS // R7
         },
         RuleKey(BUS_LANE, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -225,7 +231,7 @@ object BackMappingRules {
             setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "share_busway"))
         },
         RuleKey(MIXED_WAY, NO) to { _ ->
-            setOf(OsmTag("highway", "path"), OsmTag("bicycle", ""), OsmTag("cycleway", "")) // R7
+            setOf(OsmTag("highway", "path"), OsmTag("bicycle", "")) + REMOVE_CYCLEWAY_TAGS // R7
         },
         RuleKey(MIXED_WAY, CYCLE_HIGHWAY) to { _ ->
             setOf(OsmTag("cycle_highway", "yes")) // Added, even though this is not a way tags
@@ -284,9 +290,8 @@ object BackMappingRules {
             setOf(
                 OsmTag("highway", "path"),
                 OsmTag("bicycle", ""),
-                OsmTag("cycleway", ""),
-                OsmTag("cycle_highway", ""), // Added, even though this is not a way tags
-            )
+                OsmTag("cycle_highway", ""),
+            ) + REMOVE_CYCLEWAY_TAGS
         },
     )
 

--- a/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
@@ -781,7 +781,7 @@ enum class BikeInfrastructure(
                 )
         }
 
-        private val CYCLEWAY_INFRA_VALUES = listOf(
+        private val CYCLEWAY_INFRA_VALUES = hashSetOf(
             OsmValue.LANE.value,
             OsmValue.SHARED_LANE.value,
             OsmValue.TRACK.value,
@@ -790,14 +790,11 @@ enum class BikeInfrastructure(
             OsmValue.SHARE_BUS_WAY.value,
         )
 
-        private val hasCyclewayInfrastructure: (Map<String, Any>) -> Boolean = { tags ->
-            listOf(
-                tags[OsmTag.CYCLEWAY.key],
-                tags[OsmTag.CYCLEWAY_RIGHT.key],
-                tags[OsmTag.CYCLEWAY_LEFT.key],
-                tags[OsmTag.CYCLEWAY_BOTH.key],
-            ).any { (it as? String) in CYCLEWAY_INFRA_VALUES }
-        }
+        private fun hasCyclewayInfrastructure(tags: Map<String, Any>): Boolean =
+            tags[OsmTag.CYCLEWAY.key] as? String in CYCLEWAY_INFRA_VALUES ||
+                tags[OsmTag.CYCLEWAY_RIGHT.key] as? String in CYCLEWAY_INFRA_VALUES ||
+                tags[OsmTag.CYCLEWAY_LEFT.key] as? String in CYCLEWAY_INFRA_VALUES ||
+                tags[OsmTag.CYCLEWAY_BOTH.key] as? String in CYCLEWAY_INFRA_VALUES
 
         val isCycleHighway: (Map<String, Any>) -> Boolean = { tags ->
             val cycleHighway = tags[OsmTag.CYCLE_HIGHWAY.key] as? String

--- a/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
@@ -282,12 +282,15 @@ enum class BikeInfrastructure(
             if (isCycleHighway(tags)) return CYCLE_HIGHWAY
             if (isBikeRoad(tags)) return BICYCLE_ROAD
 
-            if ((tags.containsKey(OsmTag.ACCESS.key) && isNotAccessible(tags)) ||
-                (tags.containsKey(OsmTag.TRAM.key) && tags[OsmTag.TRAM.key] == OsmValue.YES.value)
-            ) {
-                return NO // unpacked from `service`
+            // Explicit cycleway infrastructure also takes priority [BIK-2058]
+            if (!hasCyclewayInfrastructure(tags)) {
+                if ((tags.containsKey(OsmTag.ACCESS.key) && isNotAccessible(tags)) ||
+                    (tags.containsKey(OsmTag.TRAM.key) && tags[OsmTag.TRAM.key] == OsmValue.YES.value)
+                ) {
+                    return NO // unpacked from `service`
+                }
+                if (isService(tags)) return SERVICE_MISC
             }
-            if (isService(tags)) return SERVICE_MISC
 
             if (bicycleWayRight(tags)) {
                 return when {
@@ -776,6 +779,24 @@ enum class BikeInfrastructure(
             !isIndoor(tags) && (
                 (isFootpath(tags) && !canBike(tags)) || (isPath(tags) && canWalkLeft(tags) && !canBike(tags))
                 )
+        }
+
+        private val CYCLEWAY_INFRA_VALUES = listOf(
+            OsmValue.LANE.value,
+            OsmValue.SHARED_LANE.value,
+            OsmValue.TRACK.value,
+            OsmValue.SIDE_PATH.value,
+            OsmValue.CROSSING.value,
+            OsmValue.SHARE_BUS_WAY.value,
+        )
+
+        private val hasCyclewayInfrastructure: (Map<String, Any>) -> Boolean = { tags ->
+            listOf(
+                tags[OsmTag.CYCLEWAY.key],
+                tags[OsmTag.CYCLEWAY_RIGHT.key],
+                tags[OsmTag.CYCLEWAY_LEFT.key],
+                tags[OsmTag.CYCLEWAY_BOTH.key],
+            ).any { (it as? String) in CYCLEWAY_INFRA_VALUES }
         }
 
         val isCycleHighway: (Map<String, Any>) -> Boolean = { tags ->

--- a/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BikeInfrastructure.kt
@@ -282,8 +282,8 @@ enum class BikeInfrastructure(
             if (isCycleHighway(tags)) return CYCLE_HIGHWAY
             if (isBikeRoad(tags)) return BICYCLE_ROAD
 
-            // Explicit cycleway infrastructure also takes priority [BIK-2058]
-            if (!hasCyclewayInfrastructure(tags)) {
+            // Explicit bike infrastructure also takes priority [BIK-2058]
+            if (!hasExplicitBikeInfrastructure(tags)) {
                 if ((tags.containsKey(OsmTag.ACCESS.key) && isNotAccessible(tags)) ||
                     (tags.containsKey(OsmTag.TRAM.key) && tags[OsmTag.TRAM.key] == OsmValue.YES.value)
                 ) {
@@ -790,8 +790,10 @@ enum class BikeInfrastructure(
             OsmValue.SHARE_BUS_WAY.value,
         )
 
-        private fun hasCyclewayInfrastructure(tags: Map<String, Any>): Boolean =
-            tags[OsmTag.CYCLEWAY.key] as? String in CYCLEWAY_INFRA_VALUES ||
+        private fun hasExplicitBikeInfrastructure(tags: Map<String, Any>): Boolean =
+            tags[OsmTag.HIGHWAY.key] as? String == OsmValue.CYCLEWAY.value ||
+                tags[OsmTag.BICYCLE.key] as? String == OsmValue.DESIGNATED.value ||
+                tags[OsmTag.CYCLEWAY.key] as? String in CYCLEWAY_INFRA_VALUES ||
                 tags[OsmTag.CYCLEWAY_RIGHT.key] as? String in CYCLEWAY_INFRA_VALUES ||
                 tags[OsmTag.CYCLEWAY_LEFT.key] as? String in CYCLEWAY_INFRA_VALUES ||
                 tags[OsmTag.CYCLEWAY_BOTH.key] as? String in CYCLEWAY_INFRA_VALUES

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -140,6 +140,29 @@ class BackMappingMatrixTest {
     }
 
     @TestFactory
+    fun `to NO should not stall when way has cycleway=track`(): List<DynamicTest> {
+        // Every ->NO rule must remove the cycleway tag, otherwise the
+        // hasCyclewayInfrastructure guard skips isService() and the way
+        // re-classifies as bike infra instead of NO.
+        val categories = SimplifiedBikeInfrastructure.entries.filter {
+            it != SimplifiedBikeInfrastructure.NO
+        }
+
+        return categories.map { from ->
+            DynamicTest.dynamicTest("$from → NO with cycleway=track") {
+                val context = minimalContextFor(from) + mapOf("cycleway" to "track")
+                assertDoesNotThrow {
+                    RadSimDeltaEngine.computeDelta(
+                        currentTags = context,
+                        key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                        value = SimplifiedBikeInfrastructure.NO.value
+                    )
+                }
+            }
+        }
+    }
+
+    @TestFactory
     fun `all infrastructure combinations should back-map without recursion or stall`(): List<DynamicTest> {
         val values = SimplifiedBikeInfrastructure.entries
 

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -74,6 +74,71 @@ class BackMappingMatrixTest {
         }
     }
 
+    @Test
+    fun `NO to BICYCLE_LANE should not stall when way has access=no`() {
+        // [BIK-2058] Reproducer: way 18030960 in Zwickau, classified as NO due to access=no.
+        // R20 adds cycleway=lane but the access=no check in toRadSim() returned NO before
+        // reaching isBikeLaneRight(), causing a stall.
+        val accessNoTags = mapOf(
+            "highway" to "secondary",
+            "access" to "no",
+            "@id" to "18030960",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+
+        assertDoesNotThrow {
+            RadSimDeltaEngine.computeDelta(
+                currentTags = accessNoTags,
+                key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                value = SimplifiedBikeInfrastructure.BICYCLE_LANE.value
+            )
+        }
+    }
+
+    @Test
+    fun `NO to BICYCLE_LANE should not stall when current way is a service road`() {
+        // isService() matches highway=service before isBikeLaneRight() is reached.
+        val serviceTags = mapOf(
+            "highway" to "service",
+            "@id" to "99999",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+
+        assertDoesNotThrow {
+            RadSimDeltaEngine.computeDelta(
+                currentTags = serviceTags,
+                key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                value = SimplifiedBikeInfrastructure.BICYCLE_LANE.value
+            )
+        }
+    }
+
+    @Test
+    fun `NO to BUS_LANE should not stall when way has access=no`() {
+        // Same class of bug as NO->BICYCLE_LANE: R21 adds cycleway=share_busway but
+        // access=no check fires first.
+        val accessNoTags = mapOf(
+            "highway" to "secondary",
+            "access" to "no",
+            "@id" to "99998",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+
+        assertDoesNotThrow {
+            RadSimDeltaEngine.computeDelta(
+                currentTags = accessNoTags,
+                key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                value = SimplifiedBikeInfrastructure.BUS_LANE.value
+            )
+        }
+    }
+
     @TestFactory
     fun `all infrastructure combinations should back-map without recursion or stall`(): List<DynamicTest> {
         val values = SimplifiedBikeInfrastructure.entries

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -184,23 +184,26 @@ class BackMappingMatrixTest {
     }
 
     @TestFactory
-    fun `to NO should not stall when way has cycleway=track`(): List<DynamicTest> {
-        // Every ->NO rule must remove the cycleway tag, otherwise the
+    fun `to NO should not stall when way has cycleway infra tags`(): List<DynamicTest> {
+        // Every ->NO rule must remove all cycleway tags, otherwise the
         // hasExplicitBikeInfrastructure guard skips isService() and the way
         // re-classifies as bike infra instead of NO.
         val categories = SimplifiedBikeInfrastructure.entries.filter {
             it != SimplifiedBikeInfrastructure.NO
         }
+        val cyclewayKeys = listOf("cycleway", "cycleway:right", "cycleway:both")
 
-        return categories.map { from ->
-            DynamicTest.dynamicTest("$from → NO with cycleway=track") {
-                val context = minimalContextFor(from) + mapOf("cycleway" to "track")
-                assertDoesNotThrow {
-                    RadSimDeltaEngine.computeDelta(
-                        currentTags = context,
-                        key = SimplifiedBikeInfrastructure.RADSIM_TAG,
-                        value = SimplifiedBikeInfrastructure.NO.value
-                    )
+        return categories.flatMap { from ->
+            cyclewayKeys.map { key ->
+                DynamicTest.dynamicTest("$from → NO with $key=track") {
+                    val context = minimalContextFor(from) + mapOf(key to "track")
+                    assertDoesNotThrow {
+                        RadSimDeltaEngine.computeDelta(
+                            currentTags = context,
+                            key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                            value = SimplifiedBikeInfrastructure.NO.value
+                        )
+                    }
                 }
             }
         }

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -139,10 +139,54 @@ class BackMappingMatrixTest {
         }
     }
 
+    @Test
+    fun `NO to BICYCLE_WAY should not stall when way has access=no`() {
+        // R19 sets highway=cycleway + bicycle=designated but no cycleway* tag.
+        // The guard must also recognize highway=cycleway as explicit bike infra.
+        val accessNoTags = mapOf(
+            "highway" to "secondary",
+            "access" to "no",
+            "@id" to "99997",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+
+        assertDoesNotThrow {
+            RadSimDeltaEngine.computeDelta(
+                currentTags = accessNoTags,
+                key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                value = SimplifiedBikeInfrastructure.BICYCLE_WAY.value
+            )
+        }
+    }
+
+    @Test
+    fun `NO to MIXED_WAY should not stall when way has access=no`() {
+        // R22 sets highway=path + bicycle=designated but no cycleway* tag.
+        // The guard must also recognize bicycle=designated as explicit bike infra.
+        val accessNoTags = mapOf(
+            "highway" to "secondary",
+            "access" to "no",
+            "@id" to "99996",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+
+        assertDoesNotThrow {
+            RadSimDeltaEngine.computeDelta(
+                currentTags = accessNoTags,
+                key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                value = SimplifiedBikeInfrastructure.MIXED_WAY.value
+            )
+        }
+    }
+
     @TestFactory
     fun `to NO should not stall when way has cycleway=track`(): List<DynamicTest> {
         // Every ->NO rule must remove the cycleway tag, otherwise the
-        // hasCyclewayInfrastructure guard skips isService() and the way
+        // hasExplicitBikeInfrastructure guard skips isService() and the way
         // re-classifies as bike infra instead of NO.
         val categories = SimplifiedBikeInfrastructure.entries.filter {
             it != SimplifiedBikeInfrastructure.NO

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -47,7 +47,7 @@ class BackMappingRulesTest {
 
     @Test
     fun `R7 - highway=path bicycle=NULL`() {
-        val expected = tags("highway" to "path", "bicycle" to "")
+        val expected = tags("highway" to "path", "bicycle" to "", "cycleway" to "")
         val actual = BackMappingRules.applyRule(
             SimplifiedBikeInfrastructure.BICYCLE_WAY,
             SimplifiedBikeInfrastructure.NO,

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -47,7 +47,14 @@ class BackMappingRulesTest {
 
     @Test
     fun `R7 - highway=path bicycle=NULL`() {
-        val expected = tags("highway" to "path", "bicycle" to "", "cycleway" to "")
+        val expected = tags(
+            "highway" to "path",
+            "bicycle" to "",
+            "cycleway" to "",
+            "cycleway:right" to "",
+            "cycleway:left" to "",
+            "cycleway:both" to "",
+        )
         val actual = BackMappingRules.applyRule(
             SimplifiedBikeInfrastructure.BICYCLE_WAY,
             SimplifiedBikeInfrastructure.NO,

--- a/src/test/kotlin/de/radsim/translation/model/BikeInfrastructureTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BikeInfrastructureTest.kt
@@ -233,7 +233,8 @@ class BikeInfrastructureTest {
                         "cycleway:right" to "track",
                         "sidewalk:right" to "yes"
                     ),
-                    BikeInfrastructure.SERVICE_MISC
+                    // [BIK-2058] cycleway infra now takes priority over service
+                    BikeInfrastructure.MIXED_WAY_RIGHT_NO_LEFT
                 ),
                 BikeInfrastructureParameters(
                     mapOf(
@@ -253,7 +254,8 @@ class BikeInfrastructureTest {
                         "foot" to "yes",
                         "segregated" to "no"
                     ),
-                    BikeInfrastructure.SERVICE_MISC
+                    // [BIK-2058] cycleway infra now takes priority over service
+                    BikeInfrastructure.BUS_LANE_RIGHT_MIXED_LEFT
                 ),
 
                 // OSM tags that should map to 'no' due to not accessible

--- a/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
@@ -77,6 +77,9 @@ class SimplifiedBikeInfrastructureTest {
                 OsmTag("highway", "path"),
                 OsmTag("bicycle", ""),
                 OsmTag("cycleway", ""),
+                OsmTag("cycleway:right", ""),
+                OsmTag("cycleway:left", ""),
+                OsmTag("cycleway:both", ""),
             ),
             result
         )

--- a/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
@@ -75,7 +75,8 @@ class SimplifiedBikeInfrastructureTest {
         assertEquals(
             setOf(
                 OsmTag("highway", "path"),
-                OsmTag("bicycle", "")
+                OsmTag("bicycle", ""),
+                OsmTag("cycleway", ""),
             ),
             result
         )


### PR DESCRIPTION
## Summary

- Fixes `IllegalStateException: Back-mapping stalled: NO -> BICYCLE_LANE produced no category change` in production (Zwickau, wayId=18030960)
- Root cause: `access=no` / `tram=yes` / `isService()` early-exits in `BikeInfrastructure.toRadSim()` fired before `isBikeLaneRight()` was reached, so adding `cycleway=lane` via R20 never changed the classification
- Explicit cycleway infrastructure tags now skip the access/service early-exit, following the same principle as the existing `isCycleHighway` / `isBikeRoad` priority block
- Also fixes `BICYCLE_LANE->NO` and `BUS_LANE->NO` back-mapping rules to remove the `cycleway` tag (pre-existing bug masked by the service check)

## Test plan

- [x] 3 regression tests added to `BackMappingMatrixTest` (NO->BICYCLE_LANE with access=no, NO->BICYCLE_LANE with highway=service, NO->BUS_LANE with access=no)
- [x] Verified regression tests fail before fix, pass after
- [x] 2 forward-mapping expectations updated in `BikeInfrastructureTest` (path+cycleway:right=track, path+cycleway:right=share_busway now correctly classify as infra instead of SERVICE_MISC)
- [x] Full test suite passes (299 tests)
- [x] Detekt clean