### PR TITLE
[BIK-2092] Fix back-mapping stall for segregated designated paths

### DIFF
--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -32,15 +32,38 @@ object BackMappingRules {
     )
 
     /**
-     * Side-specific cycleway tags, without the bare `cycleway` key.
+     * Tags which mark the way itself as a path for bicycles and pedestrians.
      *
-     * A rule which sets the bare `cycleway` key must remove these. A surviving
-     * `cycleway:right=track` contradicts the new value and keeps `isBikePathRight` true. [BIK-2092]
+     * A lane and a bus lane are markings on the carriageway, so the way becomes an ordinary road.
+     * The path signature is then wrong, and `highway=secondary` together with `bicycle=designated`
+     * is a contradiction in OSM.
+     *
+     * The removals are also what stops the back-mapping from stalling. Four predicates in
+     * [BikeInfrastructure] keep a way in `BICYCLE_WAY` after the rule sets `highway=secondary`:
+     *  - `isSegregated` matches any key which contains "segregated", not the bare key alone.
+     *  - `isObligatedSegregated` reads traffic sign 241 and ignores `segregated` completely.
+     *  - `isBikePathRight` matches a key which contains "right:bicycle", and a side-specific
+     *    `cycleway:right=track`.
+     *  - the designated-path clause needs `bicycle` and `foot` at the same time.
+     *
+     * Every one of those paths needs `bicycle` or `foot`, so both must go. The engine then reaches
+     * the target category instead of aborting the whole base net job. [BIK-2092]
+     *
+     * The bare `cycleway` key is absent on purpose. The two rules set it to the new value, and a
+     * set which holds both a removal and a value for one key applies in an undefined order.
+     *
+     * `traffic_sign` stays. It can carry unrelated signs, such as 274 for a speed limit.
      */
-    private val REMOVE_SIDE_CYCLEWAY_TAGS = setOf(
+    private val REMOVE_PATH_TAGS = setOf(
+        OsmTag("bicycle", ""),
+        OsmTag("foot", ""),
+        OsmTag("segregated", ""),
         OsmTag("cycleway:right", ""),
         OsmTag("cycleway:left", ""),
         OsmTag("cycleway:both", ""),
+        OsmTag("cycleway:right:bicycle", ""),
+        OsmTag("cycleway:left:bicycle", ""),
+        OsmTag("cycleway:both:bicycle", ""),
     )
 
     private val rules: Map<RuleKey, (Map<String, Any>) -> Set<OsmTag>> = mapOf(
@@ -139,24 +162,11 @@ object BackMappingRules {
         RuleKey(BICYCLE_WAY, BICYCLE_ROAD) to { _ ->
             setOf(OsmTag("highway", "residential"), OsmTag("bicycle_road", "yes"))
         },
-        // A lane and a bus lane are markings on the carriageway. The way therefore stops being a
-        // path, so the delta must also clear the path signature. `bicycleWayRight`/`bicycleWayLeft`
-        // still match `bicycle=designated` + `foot=designated` + `segregated=yes`, and they still
-        // match a side-specific `cycleway:right=track`. Without the removals the category never
-        // changes and the engine stalls, which aborts the whole base net job. [BIK-2092]
         RuleKey(BICYCLE_WAY, BICYCLE_LANE) to { _ ->
-            setOf(
-                OsmTag("highway", "secondary"),
-                OsmTag("cycleway", "lane"),
-                OsmTag("segregated", ""),
-            ) + REMOVE_SIDE_CYCLEWAY_TAGS
+            setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "lane")) + REMOVE_PATH_TAGS
         },
         RuleKey(BICYCLE_WAY, BUS_LANE) to { _ ->
-            setOf(
-                OsmTag("highway", "secondary"),
-                OsmTag("cycleway", "share_busway"),
-                OsmTag("segregated", ""),
-            ) + REMOVE_SIDE_CYCLEWAY_TAGS
+            setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "share_busway")) + REMOVE_PATH_TAGS
         },
         RuleKey(BICYCLE_WAY, MIXED_WAY) to { tags ->
             when (tags["highway"]) {

--- a/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
+++ b/src/main/kotlin/de/radsim/translation/model/BackMappingRules.kt
@@ -31,6 +31,18 @@ object BackMappingRules {
         OsmTag("cycleway:both", ""),
     )
 
+    /**
+     * Side-specific cycleway tags, without the bare `cycleway` key.
+     *
+     * A rule which sets the bare `cycleway` key must remove these. A surviving
+     * `cycleway:right=track` contradicts the new value and keeps `isBikePathRight` true. [BIK-2092]
+     */
+    private val REMOVE_SIDE_CYCLEWAY_TAGS = setOf(
+        OsmTag("cycleway:right", ""),
+        OsmTag("cycleway:left", ""),
+        OsmTag("cycleway:both", ""),
+    )
+
     private val rules: Map<RuleKey, (Map<String, Any>) -> Set<OsmTag>> = mapOf(
 
         // -------------------------------------------------------------------
@@ -127,11 +139,24 @@ object BackMappingRules {
         RuleKey(BICYCLE_WAY, BICYCLE_ROAD) to { _ ->
             setOf(OsmTag("highway", "residential"), OsmTag("bicycle_road", "yes"))
         },
+        // A lane and a bus lane are markings on the carriageway. The way therefore stops being a
+        // path, so the delta must also clear the path signature. `bicycleWayRight`/`bicycleWayLeft`
+        // still match `bicycle=designated` + `foot=designated` + `segregated=yes`, and they still
+        // match a side-specific `cycleway:right=track`. Without the removals the category never
+        // changes and the engine stalls, which aborts the whole base net job. [BIK-2092]
         RuleKey(BICYCLE_WAY, BICYCLE_LANE) to { _ ->
-            setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "lane"))
+            setOf(
+                OsmTag("highway", "secondary"),
+                OsmTag("cycleway", "lane"),
+                OsmTag("segregated", ""),
+            ) + REMOVE_SIDE_CYCLEWAY_TAGS
         },
         RuleKey(BICYCLE_WAY, BUS_LANE) to { _ ->
-            setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "share_busway"))
+            setOf(
+                OsmTag("highway", "secondary"),
+                OsmTag("cycleway", "share_busway"),
+                OsmTag("segregated", ""),
+            ) + REMOVE_SIDE_CYCLEWAY_TAGS
         },
         RuleKey(BICYCLE_WAY, MIXED_WAY) to { tags ->
             when (tags["highway"]) {

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -238,6 +238,104 @@ class BackMappingMatrixTest {
     }
 
     @TestFactory
+    fun `designated path variants should back-map to a carriageway marking`(): List<DynamicTest> {
+        // [BIK-2092] The first fix removed the bare `segregated` key only. Three classifier
+        // predicates read more than that key, so these variants still stalled:
+        //  - `isSegregated` matches any key which contains "segregated", not the bare key.
+        //  - `isObligatedSegregated` reads traffic sign 241 and ignores `segregated`.
+        //  - `isBikePathRight` matches a key which contains "right:bicycle".
+        // The rules therefore also drop `bicycle` and `foot`, which every one of those
+        // paths needs. The backend filters the side-specific keys today
+        // (RadSimToOsmTagMerger.filter), but the library must not depend on that.
+        val variants = mapOf(
+            "sidewalk:both:segregated" to mapOf(
+                "highway" to "path",
+                "bicycle" to "designated",
+                "foot" to "designated",
+                "sidewalk:both:segregated" to "yes",
+            ),
+            "cycleway:right:segregated" to mapOf(
+                "highway" to "path",
+                "bicycle" to "designated",
+                "foot" to "designated",
+                "cycleway:right:segregated" to "yes",
+            ),
+            "traffic_sign 241" to mapOf(
+                "highway" to "path",
+                "bicycle" to "designated",
+                "foot" to "designated",
+                "traffic_sign" to "241",
+            ),
+            "traffic_sign:forward 237;241" to mapOf(
+                "highway" to "track",
+                "bicycle" to "designated",
+                "foot" to "designated",
+                "traffic_sign:forward" to "237;241",
+            ),
+            "cycleway:right:bicycle designated" to mapOf(
+                "highway" to "path",
+                "bicycle" to "designated",
+                "cycleway:right:bicycle" to "designated",
+            ),
+        )
+        val targets = listOf(SimplifiedBikeInfrastructure.BICYCLE_LANE, SimplifiedBikeInfrastructure.BUS_LANE)
+
+        return variants.flatMap { (name, tags) ->
+            targets.map { to ->
+                DynamicTest.dynamicTest("$name → $to") {
+                    val context = tags + mapOf(
+                        "@id" to "26852579",
+                        "base_id" to "1",
+                        "type" to "segment",
+                        "segment_length" to "10",
+                    )
+                    val delta = RadSimDeltaEngine.computeDelta(
+                        currentTags = context,
+                        key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                        value = to.value
+                    )
+                    assertEquals(to, BikeInfrastructure.toRadSim(apply(context, delta)).simplified)
+                }
+            }
+        }
+    }
+
+    @TestFactory
+    fun `traffic sign 241 should back-map to a carriageway marking from every category`(): List<DynamicTest> {
+        // [BIK-2092] BICYCLE_ROAD and CYCLE_HIGHWAY reach BICYCLE_LANE through an intermediate
+        // BICYCLE_WAY state, so they stalled on the same leftover traffic sign.
+        val sources = mapOf(
+            SimplifiedBikeInfrastructure.BICYCLE_ROAD to mapOf("bicycle_road" to "yes"),
+            SimplifiedBikeInfrastructure.CYCLE_HIGHWAY to mapOf("cycle_highway" to "yes"),
+        )
+        val targets = listOf(SimplifiedBikeInfrastructure.BICYCLE_LANE, SimplifiedBikeInfrastructure.BUS_LANE)
+
+        return sources.flatMap { (from, signature) ->
+            targets.map { to ->
+                DynamicTest.dynamicTest("$from (traffic_sign=241) → $to") {
+                    val context = signature + mapOf(
+                        "highway" to "path",
+                        "bicycle" to "designated",
+                        "foot" to "designated",
+                        "traffic_sign" to "241",
+                        "@id" to "26852580",
+                        "base_id" to "1",
+                        "type" to "segment",
+                        "segment_length" to "10",
+                    )
+                    assertDoesNotThrow {
+                        RadSimDeltaEngine.computeDelta(
+                            currentTags = context,
+                            key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                            value = to.value
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @TestFactory
     fun `side specific bike path should back-map to all categories without stall`(): List<DynamicTest> {
         // [BIK-2092] A side-specific `cycleway:right=track` also makes `isBikePathRight` true.
         // The BICYCLE_WAY -> BICYCLE_LANE rule sets the bare `cycleway` key only, so the

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingMatrixTest.kt
@@ -18,7 +18,9 @@
  */
 package de.radsim.translation.model
 
+import de.cyface.model.osm.OsmTag
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
@@ -184,6 +186,89 @@ class BackMappingMatrixTest {
     }
 
     @TestFactory
+    fun `segregated designated path should back-map to all categories without stall`(): List<DynamicTest> {
+        // [BIK-2092] Reproducer: way 26852577 in Muenster aborted the whole base net job.
+        // The way is a segregated designated path, so `bicycleWayRight` classifies it as
+        // BICYCLE_WAY through `bicycle=designated` + `foot=designated` + `segregated=yes`.
+        // The BICYCLE_WAY -> BICYCLE_LANE rule only set `highway=secondary` + `cycleway=lane`,
+        // which leaves that triple intact, so the category never changed and the engine stalled.
+        val targets = SimplifiedBikeInfrastructure.entries.filter {
+            it != SimplifiedBikeInfrastructure.BICYCLE_WAY
+        }
+
+        return targets.map { to ->
+            DynamicTest.dynamicTest("BICYCLE_WAY (segregated designated path) → $to") {
+                assertDoesNotThrow {
+                    RadSimDeltaEngine.computeDelta(
+                        currentTags = SEGREGATED_DESIGNATED_PATH,
+                        key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                        value = to.value
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `segregated designated path to BICYCLE_LANE should clear the path signature`() {
+        // [BIK-2092] The delta must remove `segregated`, otherwise `bicycleWayRight` still
+        // matches and the way stays BICYCLE_WAY.
+        val delta = RadSimDeltaEngine.computeDelta(
+            currentTags = SEGREGATED_DESIGNATED_PATH,
+            key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+            value = SimplifiedBikeInfrastructure.BICYCLE_LANE.value
+        )
+
+        val result = BikeInfrastructure.toRadSim(apply(SEGREGATED_DESIGNATED_PATH, delta)).simplified
+        assertEquals(SimplifiedBikeInfrastructure.BICYCLE_LANE, result)
+    }
+
+    @Test
+    fun `segregated designated path to BUS_LANE should clear the path signature`() {
+        // [BIK-2092] Same rule family as BICYCLE_LANE: the bus lane marking also sits on the
+        // carriageway, so the designated path signature must go.
+        val delta = RadSimDeltaEngine.computeDelta(
+            currentTags = SEGREGATED_DESIGNATED_PATH,
+            key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+            value = SimplifiedBikeInfrastructure.BUS_LANE.value
+        )
+
+        val result = BikeInfrastructure.toRadSim(apply(SEGREGATED_DESIGNATED_PATH, delta)).simplified
+        assertEquals(SimplifiedBikeInfrastructure.BUS_LANE, result)
+    }
+
+    @TestFactory
+    fun `side specific bike path should back-map to all categories without stall`(): List<DynamicTest> {
+        // [BIK-2092] A side-specific `cycleway:right=track` also makes `isBikePathRight` true.
+        // The BICYCLE_WAY -> BICYCLE_LANE rule sets the bare `cycleway` key only, so the
+        // side-specific tag survives and keeps the way in BICYCLE_WAY.
+        val sideSpecificBikePath = mapOf(
+            "highway" to "secondary",
+            "cycleway:right" to "track",
+            "segregated" to "yes",
+            "@id" to "26852578",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+        val targets = SimplifiedBikeInfrastructure.entries.filter {
+            it != SimplifiedBikeInfrastructure.BICYCLE_WAY
+        }
+
+        return targets.map { to ->
+            DynamicTest.dynamicTest("BICYCLE_WAY (cycleway:right=track) → $to") {
+                assertDoesNotThrow {
+                    RadSimDeltaEngine.computeDelta(
+                        currentTags = sideSpecificBikePath,
+                        key = SimplifiedBikeInfrastructure.RADSIM_TAG,
+                        value = to.value
+                    )
+                }
+            }
+        }
+    }
+
+    @TestFactory
     fun `to NO should not stall when way has cycleway infra tags`(): List<DynamicTest> {
         // Every ->NO rule must remove all cycleway tags, otherwise the
         // hasExplicitBikeInfrastructure guard skips isService() and the way
@@ -258,4 +343,39 @@ class BackMappingMatrixTest {
             SimplifiedBikeInfrastructure.NO ->
                 emptyMap() // NO has no signature
         }
+
+    /**
+     * Apply a back-mapping delta to a tag set, the same way the caller of the engine does.
+     * An empty value means the caller must remove the tag.
+     */
+    private fun apply(tags: Map<String, Any>, delta: Set<OsmTag>): Map<String, Any> {
+        val updated = tags.toMutableMap()
+        delta.forEach { tag ->
+            val value = tag.value
+            if (value is String && value.isEmpty()) updated.remove(tag.key) else updated[tag.key] = value
+        }
+        return updated
+    }
+
+    companion object {
+        /**
+         * Tags of way 26852577 in Muenster, which stalled the back-mapping. [BIK-2092]
+         */
+        private val SEGREGATED_DESIGNATED_PATH = mapOf(
+            "highway" to "path",
+            "bicycle" to "designated",
+            "foot" to "designated",
+            "segregated" to "yes",
+            "cycleway:surface" to "paving_stones",
+            "cycleway:width" to "1.2",
+            "footway:surface" to "paving_stones",
+            "surface" to "paving_stones",
+            "lcn" to "yes",
+            "oneway" to "yes",
+            "@id" to "26852577",
+            "base_id" to "1",
+            "type" to "segment",
+            "segment_length" to "10",
+        )
+    }
 }

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -67,7 +67,15 @@ class BackMappingRulesTest {
 
     @Test
     fun `R8 - bicycle_way to bicycle_lane`() {
-        val expected = tags("highway" to "secondary", "cycleway" to "lane")
+        // The rule also clears the path signature, so the way cannot stay BICYCLE_WAY. [BIK-2092]
+        val expected = tags(
+            "highway" to "secondary",
+            "cycleway" to "lane",
+            "segregated" to "",
+            "cycleway:right" to "",
+            "cycleway:left" to "",
+            "cycleway:both" to "",
+        )
         val actual = BackMappingRules.applyRule(
             SimplifiedBikeInfrastructure.BICYCLE_WAY,
             SimplifiedBikeInfrastructure.BICYCLE_LANE,

--- a/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/BackMappingRulesTest.kt
@@ -71,10 +71,15 @@ class BackMappingRulesTest {
         val expected = tags(
             "highway" to "secondary",
             "cycleway" to "lane",
+            "bicycle" to "",
+            "foot" to "",
             "segregated" to "",
             "cycleway:right" to "",
             "cycleway:left" to "",
             "cycleway:both" to "",
+            "cycleway:right:bicycle" to "",
+            "cycleway:left:bicycle" to "",
+            "cycleway:both:bicycle" to "",
         )
         val actual = BackMappingRules.applyRule(
             SimplifiedBikeInfrastructure.BICYCLE_WAY,

--- a/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
@@ -93,7 +93,15 @@ class SimplifiedBikeInfrastructureTest {
             current
         )
         assertEquals(
-            setOf(OsmTag("highway", "secondary"), OsmTag("cycleway", "lane")),
+            setOf(
+                OsmTag("highway", "secondary"),
+                OsmTag("cycleway", "lane"),
+                // Clear the path signature, otherwise the way stays BICYCLE_WAY. [BIK-2092]
+                OsmTag("segregated", ""),
+                OsmTag("cycleway:right", ""),
+                OsmTag("cycleway:left", ""),
+                OsmTag("cycleway:both", ""),
+            ),
             result
         )
     }

--- a/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
+++ b/src/test/kotlin/de/radsim/translation/model/SimplifiedBikeInfrastructureTest.kt
@@ -97,10 +97,15 @@ class SimplifiedBikeInfrastructureTest {
                 OsmTag("highway", "secondary"),
                 OsmTag("cycleway", "lane"),
                 // Clear the path signature, otherwise the way stays BICYCLE_WAY. [BIK-2092]
+                OsmTag("bicycle", ""),
+                OsmTag("foot", ""),
                 OsmTag("segregated", ""),
                 OsmTag("cycleway:right", ""),
                 OsmTag("cycleway:left", ""),
                 OsmTag("cycleway:both", ""),
+                OsmTag("cycleway:right:bicycle", ""),
+                OsmTag("cycleway:left:bicycle", ""),
+                OsmTag("cycleway:both:bicycle", ""),
             ),
             result
         )


### PR DESCRIPTION
## Problem

Way 26852577 in Münster aborted the whole base net job in production. Sentry showed it five times (`RADSIM-BACKEND-C`, regressed, 9 events).

The production log gives the exact tags:

```
STALL wayId=26852577 from=BICYCLE_WAY to=BICYCLE_LANE highway=path
tags=[bicycle=designated,cycleway:surface=paving_stones,cycleway:width=1.2,
foot=designated,footway:surface=paving_stones,highway=path,lcn=yes,
oneway=yes,segregated=yes,surface=paving_stones]
```

`bicycleWayRight` / `bicycleWayLeft` classify this way as `BICYCLE_WAY` through their last clause:

```kotlin
isBicycleDesignatedRight(tags) && isPedestrianDesignatedRight(tags) && isSegregated(tags)
```

The `BICYCLE_WAY → BICYCLE_LANE` rule only produced `highway=secondary` and `cycleway=lane`. That leaves `bicycle=designated`, `foot=designated`, and `segregated=yes` intact, so `toRadSim()` returned `BICYCLE_WAY` again. `RadSimDeltaEngine` then raised `Back-mapping stalled`, which failed the base net job.

`BICYCLE_WAY → BUS_LANE` had the same defect.

## Fix

Both rules now also remove `segregated` and the side-specific cycleway tags. A lane and a bus lane are markings on the carriageway, so the path signature no longer applies.

The side-specific removal covers a second variant of the same bug: a surviving `cycleway:right=track` keeps `isBikePathRight` true and stalls the transition in exactly the same way.

## Tests

`BackMappingMatrixTest` gains three test groups. All of them fail before the fix (6 failures) and pass after it:

- a `@TestFactory` over every target category, starting from the real tags of way 26852577
- two assertions that the applied delta really classifies as `BICYCLE_LANE` and `BUS_LANE`
- a `@TestFactory` over every target category, starting from a `cycleway:right=track` way

Two existing expectations were updated, because the delta of `BICYCLE_WAY → BICYCLE_LANE` is now larger.

`./gradlew test` — 333 tests, all pass. `./gradlew detekt` — clean.

## Related Sentry issues

These all come from this one root cause: `RADSIM-BACKEND-C`, `-7`, `-N`, `-M`, `-K`, `-6`, and web-app `15`–`1E`.
